### PR TITLE
fix(hardhat-polkadot-node): chospticks commands are not parsed.

### DIFF
--- a/packages/hardhat-polkadot-node/src/utils.ts
+++ b/packages/hardhat-polkadot-node/src/utils.ts
@@ -90,8 +90,7 @@ export function constructCommandArgs(args?: CommandArguments, cliCommands?: CliC
         ) {
             throw new PolkadotNodePluginError('Adapter and node cannot share the same port.');
         }
-
-        if (args.adapterCommands?.buildBlockMode && !!cliCommands?.buildBlockMode) {
+        if (args.adapterCommands?.buildBlockMode && !cliCommands?.buildBlockMode) {
             nodeCommands.push(`--build-block-mode=${args.adapterCommands.buildBlockMode}`);
         }
 

--- a/packages/hardhat-polkadot/package.json
+++ b/packages/hardhat-polkadot/package.json
@@ -2,7 +2,7 @@
     "name": "@parity/hardhat-polkadot",
     "author": "Parity Technologies <admin@parity.io>",
     "license": "AGPL-3.0",
-    "version": "0.1.2",
+    "version": "0.1.1",
     "bugs": "https://github.com/paritytech/hardhat-polkadot/issues",
     "homepage": "https://github.com/paritytech/hardhat-polkadot/tree/master/packages/hardhat-polkadot#readme",
     "repository": {
@@ -55,8 +55,8 @@
         "picocolors": "^1.1.1"
     },
     "peerDependencies": {
-        "@parity/hardhat-polkadot-node": "^0.1.0",
-        "@parity/hardhat-polkadot-resolc": "^0.1.0",
+        "@parity/hardhat-polkadot-node": "workspace:^",
+        "@parity/hardhat-polkadot-resolc": "workspace:^",
         "hardhat": "<2.23.0"
     },
     "bundledDependencies": [

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -24,11 +24,11 @@ importers:
         specifier: ^5.3.0
         version: 5.3.0
       '@parity/hardhat-polkadot-node':
-        specifier: ^0.1.0
-        version: 0.1.0(hardhat@2.22.19(ts-node@10.9.2(@types/node@22.15.3)(typescript@5.8.3))(typescript@5.8.3))
+        specifier: workspace:^
+        version: link:../hardhat-polkadot-node
       '@parity/hardhat-polkadot-resolc':
-        specifier: ^0.1.0
-        version: 0.1.0(hardhat@2.22.19(ts-node@10.9.2(@types/node@22.15.3)(typescript@5.8.3))(typescript@5.8.3))
+        specifier: workspace:^
+        version: link:../hardhat-polkadot-resolc
       enquirer:
         specifier: 2.3.0
         version: 2.3.0
@@ -468,16 +468,6 @@ packages:
 
   '@openzeppelin/contracts@5.3.0':
     resolution: {integrity: sha512-zj/KGoW7zxWUE8qOI++rUM18v+VeLTTzKs/DJFkSzHpQFPD/jKKF0TrMxBfGLl3kpdELCNccvB3zmofSzm4nlA==}
-
-  '@parity/hardhat-polkadot-node@0.1.0':
-    resolution: {integrity: sha512-5VKg3BVLWMAquJQBmgAjX2oZbj+H1jZF7Hj75RNnMcexvk5fIEk2w3c6NSSbd1jjf+13oFczTsCW14tkAqePqw==}
-    peerDependencies:
-      hardhat: <2.23.0
-
-  '@parity/hardhat-polkadot-resolc@0.1.0':
-    resolution: {integrity: sha512-XZETfU6kIXlYHlzm1q0Ch69echpsGJlN+fDxalp32bwJCAS0H0xMqaFcFGYZymYD6RMOYxM3w4+/pjR2SC0qcQ==}
-    peerDependencies:
-      hardhat: <2.23.0
 
   '@parity/revive@0.0.21':
     resolution: {integrity: sha512-D1GCsw+wJ42P9XND1ZNPxeY7dnbKtLn1Zcqwe7JOXo1c3+BIx+YOnrtJKlZ0kWBVBpeH5XlRFzv58EUsBIEu9w==}
@@ -2414,39 +2404,6 @@ snapshots:
       '@nomicfoundation/solidity-analyzer-win32-x64-msvc': 0.1.2
 
   '@openzeppelin/contracts@5.3.0': {}
-
-  '@parity/hardhat-polkadot-node@0.1.0(hardhat@2.22.19(ts-node@10.9.2(@types/node@22.15.3)(typescript@5.8.3))(typescript@5.8.3))':
-    dependencies:
-      '@types/debug': 4.1.12
-      '@types/fs-extra': 11.0.4
-      '@types/mocha': 10.0.10
-      '@types/node': 22.15.3
-      axios: 1.9.0(debug@4.4.0)
-      chalk: 4.1.2
-      debug: 4.4.0(supports-color@8.1.1)
-      hardhat: 2.22.19(ts-node@10.9.2(@types/node@22.15.3)(typescript@5.8.3))(typescript@5.8.3)
-      ts-node: 10.9.2(@types/node@22.15.3)(typescript@5.8.3)
-      typescript: 5.8.3
-    transitivePeerDependencies:
-      - '@swc/core'
-      - '@swc/wasm'
-      - supports-color
-
-  '@parity/hardhat-polkadot-resolc@0.1.0(hardhat@2.22.19(ts-node@10.9.2(@types/node@22.15.3)(typescript@5.8.3))(typescript@5.8.3))':
-    dependencies:
-      '@parity/revive': 0.0.21(debug@4.4.0)
-      '@types/debug': 4.1.12
-      '@types/node': 22.15.3
-      chalk: 4.1.2
-      debug: 4.4.0(supports-color@8.1.1)
-      hardhat: 2.22.19(ts-node@10.9.2(@types/node@22.15.3)(typescript@5.8.3))(typescript@5.8.3)
-      solc: 0.8.29(debug@4.4.0)
-      ts-node: 10.9.2(@types/node@22.15.3)(typescript@5.8.3)
-      typescript: 5.8.3
-    transitivePeerDependencies:
-      - '@swc/core'
-      - '@swc/wasm'
-      - supports-color
 
   '@parity/revive@0.0.21(debug@4.4.0)':
     dependencies:

--- a/tests/run.sh
+++ b/tests/run.sh
@@ -4,9 +4,10 @@
 set -e
 
 # 1) build and export packages/hardhat-polkadot
-cd ../packages/hardhat-polkadot
+cd ..
 pnpm install
 pnpm build
+cd ./packages/hardhat-polkadot
 HARDHAT_TGZ_FILE=$(pnpm pack | grep "hardhat-*.*.*.tgz")
 HARDHAT_POLKADOT_PACKAGE_PATH="$(pwd)/$HARDHAT_TGZ_FILE"
 export HARDHAT_POLKADOT_PACKAGE_PATH

--- a/tests/run.sh
+++ b/tests/run.sh
@@ -11,7 +11,7 @@ cd ./packages/hardhat-polkadot
 HARDHAT_TGZ_FILE=$(pnpm pack | grep "hardhat-*.*.*.tgz")
 HARDHAT_POLKADOT_PACKAGE_PATH="$(pwd)/$HARDHAT_TGZ_FILE"
 export HARDHAT_POLKADOT_PACKAGE_PATH
-cd - >/dev/null
+cd ../../tests >/dev/null
 
 # 2) create a temporary directory to run the tests
 TMP_DIR=$(mktemp -d -t hardhat-polkadot.XXXXXXX)

--- a/tests/run.sh
+++ b/tests/run.sh
@@ -7,7 +7,7 @@ set -e
 cd ../packages/hardhat-polkadot
 pnpm install
 pnpm build
-HARDHAT_TGZ_FILE=$(npm pack | grep "hardhat-*.*.*.tgz")
+HARDHAT_TGZ_FILE=$(pnpm pack | grep "hardhat-*.*.*.tgz")
 HARDHAT_POLKADOT_PACKAGE_PATH="$(pwd)/$HARDHAT_TGZ_FILE"
 export HARDHAT_POLKADOT_PACKAGE_PATH
 cd - >/dev/null


### PR DESCRIPTION
### Description
The `BuildBlockMode` command was not being parsed correctly du to the argument check being flawed.
Also reverted the umbrella `package.json` to use `workspace:^` again.