### PR TITLE
chore(dependabot): ignore chalk upgrades

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -20,4 +20,6 @@ updates:
     labels:
       - "dependencies"
     versioning-strategy: increase
+    ignore:
+      - dependency-name: "chalk"
     


### PR DESCRIPTION
### Description
Tells dependabot to ignore `chalk` upgrades, since moving to `chalk@5.*.*` breaks our usage.