### PR TITLE
fix(hardhat-polkadot): update empty config file creation

### DIFF
--- a/packages/hardhat-polkadot/src/cli/project-creation.ts
+++ b/packages/hardhat-polkadot/src/cli/project-creation.ts
@@ -203,9 +203,28 @@ async function printRecommendedDepsInstallationInstructions(projectType: SampleP
 }
 
 // exported so we can test that it uses the latest supported version of solidity
-export const EMPTY_HARDHAT_CONFIG = `/** @type import('hardhat/config').HardhatUserConfig */
+export const EMPTY_HARDHAT_CONFIG = `require('@parity/hardhat-polkadot');
+
+/** @type import('hardhat/config').HardhatUserConfig */
 module.exports = {
   solidity: "0.8.28",
+  resolc: {
+        compilerSource: 'npm',
+    },
+    networks: {
+        hardhat: {
+            polkavm: true,
+            nodeConfig: {
+                nodeBinaryPath: './bin/substrate-node',
+                dev: true,
+                rpcPort: 8000
+            },
+            adapterConfig: {
+                adapterBinaryPath: './bin/eth-rpc',
+                dev: true,
+            },
+        },
+    }
 };
 `;
 


### PR DESCRIPTION
### Description
Fixes the `EMPTY_HARDHAT_CONFIG` that wasn't setting up the empty values correctly for `hardhat-polkadot`.

Closes #115 