### PR TITLE
fix(hardhat-polkadot): updated gitignore to contain *-pvm folders

### DIFF
--- a/packages/hardhat-polkadot/recommended-gitignore.txt
+++ b/packages/hardhat-polkadot/recommended-gitignore.txt
@@ -2,6 +2,8 @@ node_modules
 .env
 
 # Hardhat files
+/cache-pvm
+/artifacts-pvm
 /cache
 /artifacts
 


### PR DESCRIPTION
Closes #125 