### PR TITLE
fix(hardhat-polkadot): code size check when running custom scripts

### DIFF
--- a/packages/hardhat-polkadot/src/sizeCheckPatch.ts
+++ b/packages/hardhat-polkadot/src/sizeCheckPatch.ts
@@ -3,7 +3,7 @@ import path from "path";
 
 
 function needsPatch() {
-    return (process.argv.includes('ignition') && process.argv.includes('deploy')) || process.argv.includes('test');
+    return (process.argv.includes('ignition') && process.argv.includes('deploy')) || process.argv.includes('test') || process.argv.includes('run');
 }
 
 export function sizeCheckPatch() {


### PR DESCRIPTION
This PR adds support for the `run` argument to the code size patch check in `sizeCheckPatch.ts`:

### Why This Change Is Needed
While npx hardhat test and npx hardhat ignition deploy correctly trigger the size check patch, running custom scripts (e.g., npx hardhat run scripts/deploy.js) does not. This results in [the original "initcode size too large" error](https://github.com/paritytech/contract-issues/issues/47) resurfacing when deploying contracts with large bytecode.

I encountered this issue when deploying Uniswap contracts with a custom deploy script ([example commit](https://github.com/papermoonio/uniswap-v2-polkadot/commit/fe03476f92cf30e36e634635e38845a8272e23ae#diff-c3527339cbf27248d3fa8d6d3f71a29f8394aac4a0b62d35R22-R25)):

```bash
Deploying UniswapV2Pair...
Error: the initcode size of this transaction is too large: it is 83699 while the max is 49152
```

This was temporarily resolved using a [JsonRpcProvider workaround](https://github.com/papermoonio/uniswap-v2-polkadot/blob/main/scripts/deploy.js#L24), but ideally, the fix should be native to the framework.

### Additional Context

Reference: https://github.com/paritytech/hardhat-polkadot/pull/116
The fix is a minimal, targeted update that ensures consistency across all entry points used for deployment.