### PR TITLE
fix(hardhat-resolc): avoid compiling cached artifacts

### DIFF
--- a/packages/hardhat-polkadot-resolc/src/utils.ts
+++ b/packages/hardhat-polkadot-resolc/src/utils.ts
@@ -43,13 +43,15 @@ export function updateDefaultCompilerConfig(solcConfigData: SolcConfigData, reso
     if (resolc.settings?.optimizer && resolc.settings?.optimizer?.enabled) {
         optimizer = Object.assign({}, resolc.settings?.optimizer);
     } else if (resolc.settings?.optimizer?.enabled === false) {
-        optimizer = Object.assign({}, { enabled: false  });
+        optimizer = Object.assign({}, { enabled: false });
+    } else {
+        optimizer = Object.assign({}, { enabled: false, runs: 200 })
     }
 
     compiler.settings = {
         ...settings,
         optimizer: { ...optimizer },
-        evmVersion: resolc.settings?.evmVersion,
+        evmVersion: resolc.settings?.evmVersion || compiler.settings.evmVersion,
     };
 
     const forceEVMLA = resolc.settings?.forceEVMLA && resolc.compilerSource === 'binary';


### PR DESCRIPTION
### Description
Small bug on how the compiler configuration was updated was preventing `hardhat` from recognizing cached artifacts.

Closes #124 