### PR TITLE
fix(hardhat-polkadot-node): deprecated adapterEndpoint

### DIFF
--- a/packages/hardhat-polkadot-node/README.md
+++ b/packages/hardhat-polkadot-node/README.md
@@ -55,9 +55,8 @@ $ npx hardhat node --fork wss://asset-hub-westend-rpc.dwellir.com
 
 | 🔧 Command | 📄 Description |
 | --- | --- |
-| --rpc-port | Port on which the server should listen. Defaults to 8000. |
+| --rpc-port | Port on which the server should listen. Defaults to 8000. It is also where the adapter will connect to when using the binaries. |
 | --node-binary-path | Path to the substrate node binary. |
-| --adapter-endpoint | Endpoint to which the adapter will connect to. Defaults to ws://localhost:8000. |
 | --adapter-binary-path | Path to the eth-rpc-adapter binary. |
 | --adapter-port | Port on which the adapter will listen to. Defaults to 8545. |
 | --dev | Whether to run the fork in dev mode. Defaults to false. |

--- a/packages/hardhat-polkadot-node/src/index.ts
+++ b/packages/hardhat-polkadot-node/src/index.ts
@@ -94,6 +94,9 @@ task(TASK_NODE_POLKADOT, "Starts a JSON-RPC server for Polkadot node")
         undefined,
         types.string,
     )
+    /**
+    * @deprecated This property should not be used
+    */
     .addOptionalParam(
         "adapterEndpoint",
         "Endpoint to which the adapter will connect to - default: ws://localhost:8000",
@@ -247,8 +250,8 @@ task(
         const nodePath = userConfig.networks?.hardhat?.nodeConfig?.nodeBinaryPath
         const adapterPath = userConfig.networks?.hardhat?.adapterConfig?.adapterBinaryPath
 
-        let nodePort = NODE_START_PORT
-        let adapterPort = ETH_RPC_ADAPTER_START_PORT
+        let nodePort = userConfig.networks?.hardhat?.nodeConfig?.rpcPort || NODE_START_PORT;
+        let adapterPort = userConfig.networks?.hardhat?.adapterConfig?.adapterPort || ETH_RPC_ADAPTER_START_PORT
         if (!!nodePath && !!adapterPath) {
             nodePort = await getAvailablePort(nodePort, MAX_PORT_ATTEMPTS)
             adapterPort = await getAvailablePort(adapterPort, MAX_PORT_ATTEMPTS)

--- a/packages/hardhat-polkadot-node/src/types.ts
+++ b/packages/hardhat-polkadot-node/src/types.ts
@@ -20,6 +20,9 @@ export interface NodeConfig {
 
 export interface AdapterConfig {
     adapterBinaryPath?: string
+    /**
+    * @deprecated This property should not be used
+    */
     adapterEndpoint?: string
     adapterPort?: number
     dev?: boolean


### PR DESCRIPTION
### Description
Currently the plugin accepts defining which port the substrate node will listen to and which endpoint the eth-rpc will connect to. Having these as separate properties doesn't make sense, since you either connect the adapter to the rpc port of the node or to another port and it fails.