### PR TITLE
fix(hardhat-polkadot-node): fix node not connecting

### DIFF
--- a/packages/hardhat-polkadot-node/src/index.ts
+++ b/packages/hardhat-polkadot-node/src/index.ts
@@ -261,10 +261,8 @@ task(
         let nodePort = userConfig.networks?.hardhat?.nodeConfig?.rpcPort || NODE_START_PORT
         let adapterPort =
             userConfig.networks?.hardhat?.adapterConfig?.adapterPort || ETH_RPC_ADAPTER_START_PORT
-        if (!!nodePath && !!adapterPath) {
-            nodePort = await getAvailablePort(nodePort, MAX_PORT_ATTEMPTS)
-            adapterPort = await getAvailablePort(adapterPort, MAX_PORT_ATTEMPTS)
-        }
+        nodePort = await getAvailablePort(nodePort, MAX_PORT_ATTEMPTS)
+        adapterPort = await getAvailablePort(adapterPort, MAX_PORT_ATTEMPTS)
 
         const nodeCommands: NodeConfig = Object.assign(
             {},
@@ -296,10 +294,8 @@ task(
 
         try {
             await server.listen(commandArgs.nodeCommands, commandArgs.adapterCommands, false)
-            if (!!nodePath && !!adapterPath) {
-                await waitForNodeToBeReady(nodePort)
-                await waitForNodeToBeReady(adapterPort, true)
-            }
+            await waitForNodeToBeReady(nodePort)
+            await waitForNodeToBeReady(adapterPort, true)
             await configureNetwork(config, network, adapterPort || nodePort)
 
             let testFailures = 0

--- a/packages/hardhat-polkadot-node/src/index.ts
+++ b/packages/hardhat-polkadot-node/src/index.ts
@@ -268,7 +268,7 @@ task(
             {},
             userConfig.networks?.hardhat?.nodeConfig,
             {
-                port: nodePort,
+                rpcPort: nodePort,
             },
         )
         const adapterCommands: AdapterConfig = Object.assign(

--- a/packages/hardhat-polkadot-node/src/index.ts
+++ b/packages/hardhat-polkadot-node/src/index.ts
@@ -255,9 +255,6 @@ task(
 
         const files = await run(TASK_TEST_GET_TEST_FILES, { testFiles })
 
-        const nodePath = userConfig.networks?.hardhat?.nodeConfig?.nodeBinaryPath
-        const adapterPath = userConfig.networks?.hardhat?.adapterConfig?.adapterBinaryPath
-
         let nodePort = userConfig.networks?.hardhat?.nodeConfig?.rpcPort || NODE_START_PORT
         let adapterPort =
             userConfig.networks?.hardhat?.adapterConfig?.adapterPort || ETH_RPC_ADAPTER_START_PORT

--- a/packages/hardhat-polkadot-node/src/servers/docker-server.ts
+++ b/packages/hardhat-polkadot-node/src/servers/docker-server.ts
@@ -4,7 +4,6 @@ import Docker from "dockerode"
 
 import { NODE_START_PORT, ETH_RPC_ADAPTER_START_PORT } from "../constants"
 import { RpcServer } from "../types"
-import { waitForNodeToBeReady } from "../utils"
 
 const ADAPTER_CONTAINER_NAME = "eth-rpc-adapter"
 const NODE_CONTAINER_NAME = "substrate-node"
@@ -55,7 +54,6 @@ export class DockerRpcServer implements RpcServer {
             cmd: ["--dev", "--rpc-port", `${nodePort}`, "--unsafe-rpc-external"],
             verbose: true,
         })
-        await waitForNodeToBeReady(nodePort)
         this.adapterContainer = await run({
             Image: "paritypr/eth-rpc:master-f331a447",
             name: ADAPTER_CONTAINER_NAME,
@@ -84,7 +82,6 @@ export class DockerRpcServer implements RpcServer {
             Tty: false,
             Env: [],
         })
-        await waitForNodeToBeReady(adapterPort, true)
 
         if (blockProcess) {
             console.info(chalk.green(`Starting the Eth RPC Adapter at 127.0.0.1:${adapterPort}`))

--- a/packages/hardhat-polkadot-node/src/utils.ts
+++ b/packages/hardhat-polkadot-node/src/utils.ts
@@ -104,7 +104,12 @@ export function constructCommandArgs(
             )
         }
 
-        if (args.nodeCommands?.nodeBinaryPath && args.nodeCommands.dev && !cliCommands?.dev && !args.forking) {
+        if (
+            args.nodeCommands?.nodeBinaryPath &&
+            args.nodeCommands.dev &&
+            !cliCommands?.dev &&
+            !args.forking
+        ) {
             nodeCommands.push(`--dev`)
         }
 

--- a/packages/hardhat-polkadot-node/src/utils.ts
+++ b/packages/hardhat-polkadot-node/src/utils.ts
@@ -62,7 +62,7 @@ export function constructCommandArgs(
 
         if (cliCommands.dev) {
             adapterCommands.push("--dev")
-            if (cliCommands.nodeBinaryPath) {
+            if (cliCommands.nodeBinaryPath && !cliCommands.fork) {
                 nodeCommands.push("--dev")
             }
         }
@@ -104,7 +104,7 @@ export function constructCommandArgs(
             )
         }
 
-        if (args.nodeCommands?.nodeBinaryPath && args.nodeCommands.dev && !cliCommands?.dev) {
+        if (args.nodeCommands?.nodeBinaryPath && args.nodeCommands.dev && !cliCommands?.dev && !args.forking) {
             nodeCommands.push(`--dev`)
         }
 


### PR DESCRIPTION
### Description
This removes the check for node and adapter path to decide if we wait for the port to be ready or not.