### PR TITLE
fix: restart node and eth-rpc

### DIFF
--- a/packages/hardhat-polkadot-node/src/core/global-interceptor.ts
+++ b/packages/hardhat-polkadot-node/src/core/global-interceptor.ts
@@ -2,7 +2,8 @@ import { HardhatRuntimeEnvironment, RunSuperFunction, TaskArguments } from "hard
 import { GlobalWithHardhatContext } from "hardhat/src/internal/context"
 import { HARDHAT_NETWORK_NAME } from "hardhat/plugins"
 import { Environment } from "hardhat/internal/core/runtime-environment"
-import { configureNetwork, startServer, waitForNodeToBeReady } from "../utils"
+import { configureNetwork, startServer } from "../utils"
+import { waitForNodeToBeReady } from "../servers/utils"
 import { PolkadotTasksWithWrappedNode } from "./global-task"
 
 export function interceptAndWrapTasksWithNode() {

--- a/packages/hardhat-polkadot-node/src/core/script-runner.ts
+++ b/packages/hardhat-polkadot-node/src/core/script-runner.ts
@@ -3,7 +3,8 @@ import { HardhatArguments } from "hardhat/types"
 import { getEnvVariablesMap } from "hardhat/internal/core/params/env-variables"
 import path from "path"
 import { CommandArguments } from "src/types"
-import { startServer, waitForNodeToBeReady } from "../utils"
+import { startServer } from "../utils"
+import { waitForNodeToBeReady } from "../servers/utils"
 
 export async function runScript(
     config: CommandArguments,

--- a/packages/hardhat-polkadot-node/src/index.ts
+++ b/packages/hardhat-polkadot-node/src/index.ts
@@ -26,13 +26,13 @@ import {
     configureNetwork,
     constructCommandArgs,
     getAvailablePort,
-    waitForNodeToBeReady,
 } from "./utils"
 import { PolkadotNodePluginError } from "./errors"
 import { interceptAndWrapTasksWithNode } from "./core/global-interceptor"
 import { runScriptWithHardhat } from "./core/script-runner"
 import { AdapterConfig, NodeConfig, RpcServer } from "./types"
 import "./type-extensions"
+import { waitForNodeToBeReady, waitForEthRpcToBeReady } from "./servers/utils"
 
 task(TASK_RUN).setAction(async (args, hre, runSuper) => {
     if (!hre.network.polkavm || hre.network.name !== HARDHAT_NETWORK_NAME) {
@@ -292,7 +292,7 @@ task(
         try {
             await server.listen(commandArgs.nodeCommands, commandArgs.adapterCommands, false)
             await waitForNodeToBeReady(nodePort)
-            await waitForNodeToBeReady(adapterPort, true)
+            await waitForEthRpcToBeReady(adapterPort)
             await configureNetwork(config, network, adapterPort || nodePort)
 
             let testFailures = 0

--- a/packages/hardhat-polkadot-node/src/servers/docker-server.ts
+++ b/packages/hardhat-polkadot-node/src/servers/docker-server.ts
@@ -32,7 +32,7 @@ export class DockerRpcServer implements RpcServer {
         adapterArgs: string[] = [],
         blockProcess: boolean = true,
     ): Promise<void> {
-        const adapterPortArg = adapterArgs.find((arg) => arg.startsWith("--port="))
+        const adapterPortArg = adapterArgs.find((arg) => arg.startsWith("--rpc-port="))
         const adapterPort = adapterPortArg
             ? parseInt(adapterPortArg.split("=")[1], 10)
             : ETH_RPC_ADAPTER_START_PORT

--- a/packages/hardhat-polkadot-node/src/servers/path-to-binaries-server.ts
+++ b/packages/hardhat-polkadot-node/src/servers/path-to-binaries-server.ts
@@ -53,11 +53,10 @@ export class PathToBinariesRpcServer implements RpcServer {
                 )
             }
 
-            const adapterPortArg = adapterArgs.find((arg) => arg.startsWith("--port="))
+            const adapterPortArg = adapterArgs.find((arg) => arg.startsWith("--rpc-port="))
             const adapterPort = adapterPortArg
                 ? parseInt(adapterPortArg.split("=")[1], 10)
                 : ETH_RPC_ADAPTER_START_PORT
-
             this.adapterProcess = spawn(adapterCommand, adapterArgs, { stdio: stdioConfig })
 
             if (blockProcess) {

--- a/packages/hardhat-polkadot-node/src/servers/utils.ts
+++ b/packages/hardhat-polkadot-node/src/servers/utils.ts
@@ -4,29 +4,27 @@ import { BASE_URL, RPC_ENDPOINT_PATH } from "../constants"
 import { PolkadotNodePluginError } from "../errors"
 
 export async function waitForNodeToBeReady(port: number, maxAttempts = 20): Promise<void> {
-    const endpoint = `${BASE_URL}:${port}`
     const payload = {
         jsonrpc: "2.0",
         method: "state_getRuntimeVersion",
         params: [],
         id: 1,
     }
-    await waitForServiceToBeReady(endpoint, payload, maxAttempts)
+    await waitForServiceToBeReady(port, payload, maxAttempts)
 }
 
 export async function waitForEthRpcToBeReady(port: number, maxAttempts = 20): Promise<void> {
-    const endpoint = `${BASE_URL}:${port}`
     const payload = {
         jsonrpc: "2.0",
         method: RPC_ENDPOINT_PATH,
         params: [],
         id: 1,
     }
-    await waitForServiceToBeReady(endpoint, payload, maxAttempts)
+    await waitForServiceToBeReady(port, payload, maxAttempts)
 }
 
 async function waitForServiceToBeReady(
-    endpoint: string,
+    port: number,
     payload: object,
     maxAttempts: number,
 ): Promise<void> {
@@ -34,6 +32,7 @@ async function waitForServiceToBeReady(
     let waitTime = 1000
     const backoffFactor = 2
     const maxWaitTime = 30000
+    const endpoint = `${BASE_URL}:${port}`
 
     while (attempts < maxAttempts) {
         try {

--- a/packages/hardhat-polkadot-node/src/servers/utils.ts
+++ b/packages/hardhat-polkadot-node/src/servers/utils.ts
@@ -1,0 +1,58 @@
+import axios from "axios"
+
+import { BASE_URL, RPC_ENDPOINT_PATH } from "../constants"
+import { PolkadotNodePluginError } from "../errors"
+
+export async function waitForNodeToBeReady(port: number, maxAttempts = 20): Promise<void> {
+    const endpoint = `${BASE_URL}:${port}`
+    const payload = {
+        jsonrpc: "2.0",
+        method: "state_getRuntimeVersion",
+        params: [],
+        id: 1,
+    }
+    await waitForServiceToBeReady(endpoint, payload, maxAttempts)
+}
+
+export async function waitForEthRpcToBeReady(port: number, maxAttempts = 20): Promise<void> {
+    const endpoint = `${BASE_URL}:${port}`
+    const payload = {
+        jsonrpc: "2.0",
+        method: RPC_ENDPOINT_PATH,
+        params: [],
+        id: 1,
+    }
+    await waitForServiceToBeReady(endpoint, payload, maxAttempts)
+}
+
+async function waitForServiceToBeReady(
+    endpoint: string,
+    payload: object,
+    maxAttempts: number,
+): Promise<void> {
+    let attempts = 0
+    let waitTime = 1000
+    const backoffFactor = 2
+    const maxWaitTime = 30000
+
+    while (attempts < maxAttempts) {
+        try {
+            const response = await axios.post(endpoint, payload)
+
+            if (response.status == 200) {
+                return
+            }
+            // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        } catch (_e: any) {
+            // If it fails, it will just try again
+        }
+
+        attempts++
+
+        await new Promise((r) => setTimeout(r, waitTime))
+
+        waitTime = Math.min(waitTime * backoffFactor, maxWaitTime)
+    }
+
+    throw new PolkadotNodePluginError("Server didn't respond after multiple attempts")
+}

--- a/packages/hardhat-polkadot-node/src/utils.ts
+++ b/packages/hardhat-polkadot-node/src/utils.ts
@@ -94,6 +94,18 @@ export function constructCommandArgs(
 
         if (
             args.adapterCommands?.adapterPort &&
+            args.adapterCommands?.adapterPort !== args.nodeCommands?.rpcPort
+        ) {
+            adapterCommands.push(`--rpc-port=${args.adapterCommands?.adapterPort}`)
+        } else if (
+            args.adapterCommands?.adapterPort &&
+            args.adapterCommands?.adapterPort === args.nodeCommands?.rpcPort
+        ) {
+            throw new PolkadotNodePluginError("Adapter and node cannot share the same port.")
+        }
+
+        if (
+            args.adapterCommands?.adapterPort &&
             args.adapterCommands?.adapterPort === args.nodeCommands?.rpcPort
         ) {
             throw new PolkadotNodePluginError("Adapter and node cannot share the same port.")
@@ -190,7 +202,12 @@ export async function configureNetwork(
     port: number,
 ) {
     const url = `${BASE_URL}:${port}`
-    const payload = setPayload(true)
+    const payload = {
+        jsonrpc: "2.0",
+        method: RPC_ENDPOINT_PATH,
+        params: [],
+        id: 1,
+    }
     let chainId = 0
     try {
         const response = await axios.post(url, payload)

--- a/packages/hardhat-polkadot-node/src/utils.ts
+++ b/packages/hardhat-polkadot-node/src/utils.ts
@@ -141,49 +141,6 @@ export async function isPortAvailable(port: number): Promise<boolean> {
     return availableIPv4 && availableIPv6
 }
 
-function setPayload(adapter?: boolean): object {
-    return {
-        jsonrpc: "2.0",
-        method: adapter ? RPC_ENDPOINT_PATH : "state_getRuntimeVersion",
-        params: [],
-        id: 1,
-    }
-}
-
-export async function waitForNodeToBeReady(
-    port: number,
-    adapter: boolean = false,
-    maxAttempts: number = 20,
-): Promise<void> {
-    const rpcEndpoint = `${BASE_URL}:${port}`
-    const payload = setPayload(adapter)
-    let attempts = 0
-    let waitTime = 1000
-    const backoffFactor = 2
-    const maxWaitTime = 30000
-
-    while (attempts < maxAttempts) {
-        try {
-            const response = await axios.post(rpcEndpoint, payload)
-
-            if (response.status == 200) {
-                return
-            }
-            // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        } catch (_e: any) {
-            // If it fails, it will just try again
-        }
-
-        attempts++
-
-        await new Promise((r) => setTimeout(r, waitTime))
-
-        waitTime = Math.min(waitTime * backoffFactor, maxWaitTime)
-    }
-
-    throw new PolkadotNodePluginError("Server didn't respond after multiple attempts")
-}
-
 export async function getAvailablePort(startPort: number, maxAttempts: number): Promise<number> {
     let currentPort = startPort
     for (let i = 0; i < maxAttempts; i++) {


### PR DESCRIPTION
- Moves `waitForNodeToBeReady` to servers folder and splits into `waitForEthRpcToBeReady`. Previously `waitForNodeToBeReady(true)` was very confusing
- `npx hardhat test` multiple times works. The service was being launched on port 8545 but we were waiting for a response in port 8546
- reads the adapter port correctly
- replaces --port arg with --rpc-port since eth-rpc fails with --port arg