### PR TITLE
fix(hardhat-polkadot-resolc): Improve cache info and default optimization

### DIFF
--- a/packages/hardhat-polkadot-resolc/src/compile/binary.ts
+++ b/packages/hardhat-polkadot-resolc/src/compile/binary.ts
@@ -1,6 +1,6 @@
 import { spawn } from "child_process"
 import type { CompilerInput } from "hardhat/types"
-import { resolveInputs, type SolcOutput } from "@parity/resolc"
+import { type SolcOutput } from "@parity/resolc"
 import chalk from "chalk"
 import type { ResolcConfig } from "../types"
 import { extractCommands } from "../utils"
@@ -38,7 +38,7 @@ export async function compileWithBinary(
 
     const inputs = JSON.stringify({
         language: "Solidity",
-        sources: resolveInputs(input.sources),
+        sources: input.sources,
         settings: {
             optimizer: optimizerSettings,
             outputSelection: {

--- a/packages/hardhat-polkadot-resolc/src/compile/binary.ts
+++ b/packages/hardhat-polkadot-resolc/src/compile/binary.ts
@@ -9,7 +9,6 @@ import { ResolcPluginError } from "../errors"
 export async function compileWithBinary(
     input: CompilerInput,
     config: ResolcConfig,
-    solcPath?: string,
 ): Promise<SolcOutput> {
     const { compilerPath, optimizer } = config.settings!
 
@@ -19,7 +18,7 @@ export async function compileWithBinary(
         )
     }
 
-    const commands = extractCommands(config, solcPath)
+    const commands = extractCommands(config)
 
     let optimizerSettings: object | undefined
 

--- a/packages/hardhat-polkadot-resolc/src/compile/binary.ts
+++ b/packages/hardhat-polkadot-resolc/src/compile/binary.ts
@@ -9,6 +9,7 @@ import { ResolcPluginError } from "../errors"
 export async function compileWithBinary(
     input: CompilerInput,
     config: ResolcConfig,
+    solcPath?: string,
 ): Promise<SolcOutput> {
     const { compilerPath, optimizer } = config.settings!
 
@@ -18,7 +19,7 @@ export async function compileWithBinary(
         )
     }
 
-    const commands = extractCommands(config)
+    const commands = extractCommands(config, solcPath)
 
     let optimizerSettings: object | undefined
 

--- a/packages/hardhat-polkadot-resolc/src/compile/index.ts
+++ b/packages/hardhat-polkadot-resolc/src/compile/index.ts
@@ -10,14 +10,14 @@ export interface ICompiler {
     compile(input: CompilerInput, config: ResolcConfig): Promise<SolcOutput>
 }
 
-export async function compile(resolcConfig: ResolcConfig, input: CompilerInput, solcPath?: string ) {
+export async function compile(resolcConfig: ResolcConfig, input: CompilerInput) {
     let compiler: ICompiler
 
     if (resolcConfig.compilerSource === "binary") {
         if (resolcConfig.settings?.solcPath === null) {
             throw new ResolcPluginError("The path to the resolc binary is not specified.")
         }
-        compiler = new BinaryCompiler(resolcConfig, solcPath)
+        compiler = new BinaryCompiler(resolcConfig)
     } else if (resolcConfig.compilerSource === "npm") {
         if (resolcConfig.settings?.batchSize)
             console.warn(
@@ -35,10 +35,10 @@ export async function compile(resolcConfig: ResolcConfig, input: CompilerInput, 
 }
 
 export class BinaryCompiler implements ICompiler {
-    constructor(public config: ResolcConfig, public solcPath?: string) {}
+    constructor(public config: ResolcConfig) {}
 
     public async compile(input: CompilerInput) {
-        return await compileWithBinary(input, this.config, this.solcPath)
+        return await compileWithBinary(input, this.config)
     }
 }
 

--- a/packages/hardhat-polkadot-resolc/src/compile/index.ts
+++ b/packages/hardhat-polkadot-resolc/src/compile/index.ts
@@ -10,14 +10,14 @@ export interface ICompiler {
     compile(input: CompilerInput, config: ResolcConfig): Promise<SolcOutput>
 }
 
-export async function compile(resolcConfig: ResolcConfig, input: CompilerInput) {
+export async function compile(resolcConfig: ResolcConfig, input: CompilerInput, solcPath?: string ) {
     let compiler: ICompiler
 
     if (resolcConfig.compilerSource === "binary") {
         if (resolcConfig.settings?.solcPath === null) {
             throw new ResolcPluginError("The path to the resolc binary is not specified.")
         }
-        compiler = new BinaryCompiler(resolcConfig)
+        compiler = new BinaryCompiler(resolcConfig, solcPath)
     } else if (resolcConfig.compilerSource === "npm") {
         if (resolcConfig.settings?.batchSize)
             console.warn(
@@ -35,10 +35,10 @@ export async function compile(resolcConfig: ResolcConfig, input: CompilerInput) 
 }
 
 export class BinaryCompiler implements ICompiler {
-    constructor(public config: ResolcConfig) {}
+    constructor(public config: ResolcConfig, public solcPath?: string) {}
 
     public async compile(input: CompilerInput) {
-        return await compileWithBinary(input, this.config)
+        return await compileWithBinary(input, this.config, this.solcPath)
     }
 }
 

--- a/packages/hardhat-polkadot-resolc/src/compile/npm.ts
+++ b/packages/hardhat-polkadot-resolc/src/compile/npm.ts
@@ -42,20 +42,25 @@ export async function compileWithNpm(
 }
 
 export function updateSolc(version: string) {
-    // eslint-disable-next-line @typescript-eslint/no-require-imports
-    const packagePath = require(path.resolve("node_modules/solc/package.json"))
-
-    if (semver.satisfies(packagePath.version, version)) {
-        return
-    }
+    let currentVersion: string | null = null
 
     try {
-        execSync(`npm install --save-dev --save-exact solc@${version} --quiet`, {
-            stdio: "inherit",
-        })
-    } catch (error) {
-        throw new ResolcPluginError(
-            `Compilation failed during solc@${version} installtion: ${(error as Error).message}`,
-        )
+        // eslint-disable-next-line @typescript-eslint/no-require-imports
+        const pkg = require(path.resolve("node_modules/solc/package.json"))
+        currentVersion = pkg.version
+    } catch {
+        // solc not installed or unreadable
+    }
+
+    if (!currentVersion || !semver.satisfies(currentVersion, version)) {
+        try {
+            execSync(`npm install --save-dev --save-exact solc@${version} --quiet`, {
+                stdio: "inherit",
+            })
+        } catch (error) {
+            throw new ResolcPluginError(
+                `Compilation failed during solc@${version} installation: ${(error as Error).message}`,
+            )
+        }
     }
 }

--- a/packages/hardhat-polkadot-resolc/src/constants.ts
+++ b/packages/hardhat-polkadot-resolc/src/constants.ts
@@ -17,6 +17,7 @@ export const defaultBinaryResolcConfig: ResolcConfig = {
         compilerPath: "resolc",
         optimizer: {
             enabled: true,
+            runs: 200
         },
     },
 }

--- a/packages/hardhat-polkadot-resolc/src/constants.ts
+++ b/packages/hardhat-polkadot-resolc/src/constants.ts
@@ -17,7 +17,7 @@ export const defaultBinaryResolcConfig: ResolcConfig = {
         compilerPath: "resolc",
         optimizer: {
             enabled: true,
-            runs: 200
+            runs: 200,
         },
     },
 }

--- a/packages/hardhat-polkadot-resolc/src/constants.ts
+++ b/packages/hardhat-polkadot-resolc/src/constants.ts
@@ -3,7 +3,6 @@ import type { ResolcConfig } from "./types"
 export const PLUGIN_NAME = "hardhat-polkadot"
 export const RESOLC_ARTIFACT_FORMAT_VERSION = "hh-resolc-artifact-1"
 export const DEFAULT_TIMEOUT_MILISECONDS = 30000
-export const COMPILER_RESOLC_NEED_EVM_CODEGEN = `Yul codegen is only supported for solc >= 0.8. Flag forceEVMLA will automatically be set to true by default.`
 
 export const defaultNpmResolcConfig: ResolcConfig = {
     version: "latest",

--- a/packages/hardhat-polkadot-resolc/src/index.ts
+++ b/packages/hardhat-polkadot-resolc/src/index.ts
@@ -224,8 +224,7 @@ subtask(
             quiet: args.quiet,
         })
 
-        let output
-        output = await hre.run(TASK_COMPILE_SOLIDITY_RUN_SOLC, {
+        const output = await hre.run(TASK_COMPILE_SOLIDITY_RUN_SOLC, {
             input: args.input,
             solcPath: solcBuild.compilerPath,
             solcVersion: args.solcVersion,

--- a/packages/hardhat-polkadot-resolc/src/index.ts
+++ b/packages/hardhat-polkadot-resolc/src/index.ts
@@ -50,15 +50,17 @@ extendConfig((config, userConfig) => {
     if (!config.networks.hardhat.polkavm) return
 
     const isBinary = config.resolc?.compilerSource === "binary"
-    const deafaulConfig = isBinary ? defaultBinaryResolcConfig : defaultNpmResolcConfig
+    const deafaultConfig = isBinary ? defaultBinaryResolcConfig : defaultNpmResolcConfig
     const customConfig = userConfig?.resolc || {}
 
+    const optimizer = Object.assign({}, deafaultConfig.settings?.optimizer, customConfig.settings?.optimizer)
+
     config.resolc = {
-        ...deafaulConfig,
+        ...deafaultConfig,
         ...customConfig,
         settings: {
-            ...deafaulConfig.settings,
             ...customConfig.settings,
+            optimizer
         },
     }
 })
@@ -80,8 +82,8 @@ extendEnvironment((hre) => {
 
     hre.config.paths.artifacts = artifactsPath
     hre.config.paths.cache = cachePath
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    ;(hre as any).artifacts = new Artifacts(artifactsPath)
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        ; (hre as any).artifacts = new Artifacts(artifactsPath)
 
     if (
         (hre.config.solidity.compilers.length > 1 && hre.config.resolc.compilerSource === "npm") ||

--- a/packages/hardhat-polkadot-resolc/src/index.ts
+++ b/packages/hardhat-polkadot-resolc/src/index.ts
@@ -161,7 +161,7 @@ subtask(
     },
 )
 
-subtask(TASK_COMPILE_SOLIDITY_RUN_SOLC, async (args: { input: CompilerInput }, hre, runSuper) => {
+subtask(TASK_COMPILE_SOLIDITY_RUN_SOLC, async (args: { input: CompilerInput, solcPath: string }, hre, runSuper) => {
     if (!hre.network.polkavm) {
         return await runSuper(args)
     }
@@ -176,7 +176,7 @@ subtask(TASK_COMPILE_SOLIDITY_RUN_SOLC, async (args: { input: CompilerInput }, h
     if (versions.size > 1)
         throw new ResolcPluginError("Multiple Solidity versions are not supported yet.")
 
-    return await compile(hre.config.resolc, args.input)
+    return await compile(hre.config.resolc, args.input, args.solcPath)
 })
 
 subtask(

--- a/packages/hardhat-polkadot-resolc/src/index.ts
+++ b/packages/hardhat-polkadot-resolc/src/index.ts
@@ -50,17 +50,21 @@ extendConfig((config, userConfig) => {
     if (!config.networks.hardhat.polkavm) return
 
     const isBinary = config.resolc?.compilerSource === "binary"
-    const deafaultConfig = isBinary ? defaultBinaryResolcConfig : defaultNpmResolcConfig
+    const defaultConfig = isBinary ? defaultBinaryResolcConfig : defaultNpmResolcConfig
     const customConfig = userConfig?.resolc || {}
 
-    const optimizer = Object.assign({}, deafaultConfig.settings?.optimizer, customConfig.settings?.optimizer)
+    const optimizer = Object.assign(
+        {},
+        defaultConfig.settings?.optimizer,
+        customConfig.settings?.optimizer,
+    )
 
     config.resolc = {
-        ...deafaultConfig,
+        ...defaultConfig,
         ...customConfig,
         settings: {
             ...customConfig.settings,
-            optimizer
+            optimizer,
         },
     }
 })
@@ -82,8 +86,8 @@ extendEnvironment((hre) => {
 
     hre.config.paths.artifacts = artifactsPath
     hre.config.paths.cache = cachePath
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        ; (hre as any).artifacts = new Artifacts(artifactsPath)
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    ;(hre as any).artifacts = new Artifacts(artifactsPath)
 
     if (
         (hre.config.solidity.compilers.length > 1 && hre.config.resolc.compilerSource === "npm") ||

--- a/packages/hardhat-polkadot-resolc/src/index.ts
+++ b/packages/hardhat-polkadot-resolc/src/index.ts
@@ -1,6 +1,5 @@
 import {
     TASK_COMPILE_SOLIDITY_RUN_SOLC,
-    TASK_COMPILE_SOLIDITY_RUN_SOLCJS,
     TASK_COMPILE_SOLIDITY_GET_ARTIFACT_FROM_COMPILATION_OUTPUT,
     TASK_COMPILE_SOLIDITY_GET_SOLC_BUILD,
     TASK_COMPILE_SOLIDITY_LOG_COMPILATION_RESULT,
@@ -84,6 +83,16 @@ extendEnvironment((hre) => {
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     ;(hre as any).artifacts = new Artifacts(artifactsPath)
 
+    if (
+        (hre.config.solidity.compilers.length > 1 && hre.config.resolc.compilerSource === "npm") ||
+        (Object.entries(hre.config.solidity.overrides).length > 1 &&
+            hre.config.resolc.compilerSource === "npm")
+    ) {
+        throw new ResolcPluginError(
+            `Multiple solidity versions are not available when using npm as the compiler.`,
+        )
+    }
+
     hre.config.solidity.compilers.forEach(async (compiler) =>
         updateDefaultCompilerConfig({ compiler }, hre.config.resolc),
     )
@@ -161,23 +170,28 @@ subtask(
     },
 )
 
-subtask(TASK_COMPILE_SOLIDITY_RUN_SOLC, async (args: { input: CompilerInput, solcPath: string }, hre, runSuper) => {
-    if (!hre.network.polkavm) {
-        return await runSuper(args)
-    }
+subtask(
+    TASK_COMPILE_SOLIDITY_RUN_SOLC,
+    async (
+        args: { input: CompilerInput; solcPath: string; solcVersion: string },
+        hre,
+        runSuper,
+    ) => {
+        if (!hre.network.polkavm) {
+            return await runSuper(args)
+        }
 
-    const versions = new Set<string>()
-    for (const compiler of hre.config.solidity.compilers) {
-        versions.add(compiler.version)
-    }
-    for (const override of Object.values(hre.config.solidity.overrides)) {
-        versions.add(override.version)
-    }
-    if (versions.size > 1)
-        throw new ResolcPluginError("Multiple Solidity versions are not supported yet.")
+        const config = {
+            ...hre.config.resolc,
+            settings: {
+                ...hre.config.resolc.settings,
+                solcPath: args.solcPath,
+            },
+        }
 
-    return await compile(hre.config.resolc, args.input, args.solcPath)
-})
+        return await compile(config, args.input)
+    },
+)
 
 subtask(
     TASK_COMPILE_SOLIDITY_COMPILE_SOLC,
@@ -211,17 +225,11 @@ subtask(
         })
 
         let output
-        if (solcBuild.isSolcJs) {
-            output = await hre.run(TASK_COMPILE_SOLIDITY_RUN_SOLCJS, {
-                input: args.input,
-                solcJsPath: solcBuild.compilerPath,
-            })
-        } else {
-            output = await hre.run(TASK_COMPILE_SOLIDITY_RUN_SOLC, {
-                input: args.input,
-                solcPath: solcBuild.compilerPath,
-            })
-        }
+        output = await hre.run(TASK_COMPILE_SOLIDITY_RUN_SOLC, {
+            input: args.input,
+            solcPath: solcBuild.compilerPath,
+            solcVersion: args.solcVersion,
+        })
 
         await hre.run(TASK_COMPILE_SOLIDITY_LOG_RUN_COMPILER_END, {
             compilationJob: args.compilationJob,

--- a/packages/hardhat-polkadot-resolc/src/types.ts
+++ b/packages/hardhat-polkadot-resolc/src/types.ts
@@ -51,8 +51,6 @@ export interface ResolcConfig {
         solcPath?: string
         // The EVM target version to generate IR for. See https://github.com/paritytech/revive/blob/main/crates/common/src/evm_version.rs for reference.
         evmVersion?: EvmVersions
-        // Forcibly switch to EVM legacy assembly pipeline. It is useful for older revisions of `solc` 0.8, where Yul was considered highly experimental and contained more bugs than today
-        forceEVMLA?: boolean
         // Suppress specified warnings.
         suppressWarnings?: SuppresWarningsOpts[]
         // Dump all IRs to files in the specified directory. Only for testing and debugging.

--- a/packages/hardhat-polkadot-resolc/src/utils.ts
+++ b/packages/hardhat-polkadot-resolc/src/utils.ts
@@ -58,7 +58,13 @@ export function updateDefaultCompilerConfig(solcConfigData: SolcConfigData, reso
     compiler.settings = {
         ...settings,
         optimizer: { ...optimizer },
+        outputSelection: {
+            '*': {
+                '*': ['abi'],
+            },
+        },
         evmVersion: resolc.settings?.evmVersion || compiler.settings.evmVersion,
+        resolc: resolc,
     }
 
     const [major, minor] = getVersionComponents(compiler.version)

--- a/packages/hardhat-polkadot-resolc/src/utils.ts
+++ b/packages/hardhat-polkadot-resolc/src/utils.ts
@@ -1,6 +1,5 @@
 import type { Artifact, CompilerInput } from "hardhat/types"
 import { ARTIFACT_FORMAT_VERSION } from "hardhat/internal/constants"
-import chalk from "chalk"
 import { updateSolc } from "./compile/npm"
 import type { ResolcConfig, SolcConfigData } from "./types"
 import { ResolcPluginError } from "./errors"

--- a/packages/hardhat-polkadot-resolc/src/utils.ts
+++ b/packages/hardhat-polkadot-resolc/src/utils.ts
@@ -96,10 +96,6 @@ function extractStandardJSONCommands(config: ResolcConfig, commandArgs: string[]
 
     commandArgs.push(`--standard-json`)
 
-    if (settings.solcPath) {
-        commandArgs.push(`--solc=${settings.solcPath}`)
-    }
-
     if (settings.forceEVMLA) {
         commandArgs.push(`--force-evmla`)
     }
@@ -140,8 +136,10 @@ function extractStandardJSONCommands(config: ResolcConfig, commandArgs: string[]
     return commandArgs
 }
 
-export function extractCommands(config: ResolcConfig): string[] {
+export function extractCommands(config: ResolcConfig, solcPath?: string): string[] {
     const commandArgs: string[] = []
+
+    if (solcPath) commandArgs.push(`--solc=${solcPath}`)
 
     return extractStandardJSONCommands(config, commandArgs)
 }

--- a/packages/hardhat-polkadot-resolc/src/utils.ts
+++ b/packages/hardhat-polkadot-resolc/src/utils.ts
@@ -59,8 +59,8 @@ export function updateDefaultCompilerConfig(solcConfigData: SolcConfigData, reso
         ...settings,
         optimizer: { ...optimizer },
         outputSelection: {
-            '*': {
-                '*': ['abi'],
+            "*": {
+                "*": ["abi"],
             },
         },
         evmVersion: resolc.settings?.evmVersion || compiler.settings.evmVersion,


### PR DESCRIPTION
### Description
This improves adds to the cache info the settings used for `resolc`. In short, this ensures that if any setting for `resolc` changes, the compilation is being run again, since before it only checked the `solc` settings.

This also updates the default configuration behavior, to fix the entirety of the default settings being overwritten and the `runs` parameter being left as `undefined` even though it had default values that should be in place.