### PR TITLE
fix(hardhat-polkadot-resolc): updated types

### DIFF
--- a/examples/localNode.config.ts
+++ b/examples/localNode.config.ts
@@ -23,7 +23,6 @@ const config: HardhatUserConfig = {
             optimizer: {
                 enabled: true,
             },
-            evmVersion: "cancun",
             compilerPath: "path/to/resolc",
         },
     },

--- a/packages/hardhat-polkadot-resolc/src/compile/binary.ts
+++ b/packages/hardhat-polkadot-resolc/src/compile/binary.ts
@@ -1,7 +1,6 @@
 import { spawn } from "child_process"
 import type { CompilerInput } from "hardhat/types"
 import { type SolcOutput } from "@parity/resolc"
-import chalk from "chalk"
 import type { ResolcConfig } from "../types"
 import { extractCommands } from "../utils"
 import { ResolcPluginError } from "../errors"
@@ -11,12 +10,6 @@ export async function compileWithBinary(
     config: ResolcConfig,
 ): Promise<SolcOutput> {
     const { compilerPath, optimizer } = config.settings!
-
-    if (config.settings?.batchSize) {
-        console.log(
-            chalk.yellow("This property is deprecated and will be removed. Treating as no effect."),
-        )
-    }
 
     const commands = extractCommands(config)
 

--- a/packages/hardhat-polkadot-resolc/src/compile/index.ts
+++ b/packages/hardhat-polkadot-resolc/src/compile/index.ts
@@ -1,5 +1,4 @@
 import type { CompilerInput } from "hardhat/types"
-import chalk from "chalk"
 import type { SolcOutput } from "@parity/resolc"
 import type { ResolcConfig } from "../types"
 import { ResolcPluginError } from "../errors"
@@ -19,13 +18,6 @@ export async function compile(resolcConfig: ResolcConfig, input: CompilerInput) 
         }
         compiler = new BinaryCompiler(resolcConfig)
     } else if (resolcConfig.compilerSource === "npm") {
-        if (resolcConfig.settings?.batchSize)
-            console.warn(
-                chalk.yellow(
-                    "Batch compilation is only available for `binary` source.\nSetting batchSize will be ignored.",
-                ),
-            )
-
         compiler = new NpmCompiler(resolcConfig)
     } else {
         throw new ResolcPluginError(`Incorrect compiler source: ${resolcConfig.compilerSource}`)

--- a/packages/hardhat-polkadot-resolc/src/index.ts
+++ b/packages/hardhat-polkadot-resolc/src/index.ts
@@ -357,13 +357,6 @@ subtask(TASK_COMPILE_SOLIDITY_GET_COMPILER_INPUT, async (taskArgs, hre, runSuper
         return compilerInput
     }
 
-    if (
-        hre.config.resolc.settings?.suppressWarnings &&
-        hre.config.resolc.settings.suppressWarnings.length > 0
-    ) {
-        compilerInput.suppressedWarnings = hre.config.resolc.settings.suppressWarnings
-    }
-
     return compilerInput
 })
 

--- a/packages/hardhat-polkadot-resolc/src/types.ts
+++ b/packages/hardhat-polkadot-resolc/src/types.ts
@@ -1,28 +1,5 @@
 import type { CompilerInput, SolcConfig } from "hardhat/types"
 
-type EvmVersions =
-    | "homestead"
-    | "tangerineWhistle"
-    | "spuriousDragon"
-    | "byzantium"
-    | "constantinople"
-    | "petersburg"
-    | "istanbul"
-    | "berlin"
-    | "london"
-    | "paris"
-    | "shanghai"
-    | "cancun"
-
-type SuppresWarningsOpts =
-    | "ecrecover"
-    | "sendtransfer"
-    | "extcodesize"
-    | "txorigin"
-    | "blocktimestamp"
-    | "blocknumber"
-    | "blockhash"
-
 export interface ResolcConfig {
     version: string
     compilerSource?: "binary" | "npm"
@@ -34,8 +11,6 @@ export interface ResolcConfig {
         includePaths?: string[]
         // Allow a given path for imports. A list of paths can be supplied by separating them with a comma. Passed to `solc` without changes.
         allowPaths?: string
-        // Create one file per component and contract/file at the specified directory, if given.
-        outputDir?: string
         // Optimizer settings.
         optimizer?: {
             // Enable the optimizer.
@@ -49,10 +24,6 @@ export interface ResolcConfig {
         }
         // Specify the path to the `solc` executable.
         solcPath?: string
-        // The EVM target version to generate IR for. See https://github.com/paritytech/revive/blob/main/crates/common/src/evm_version.rs for reference.
-        evmVersion?: EvmVersions
-        // Suppress specified warnings.
-        suppressWarnings?: SuppresWarningsOpts[]
         // Dump all IRs to files in the specified directory. Only for testing and debugging.
         debugOutputDir?: string
         // If compilerSource == "npm", this option is ignored.
@@ -61,12 +32,6 @@ export interface ResolcConfig {
         contractsToCompile?: string[]
         // Generate source based debug information in the output code file. This only has an effect with the LLVM-IR code generator and is ignored otherwise.
         emitDourceDebugInfo?: boolean
-        // Disable the `solc` optimizer.
-        disableSolcOptimizer?: boolean
-        /**
-         * @deprecated This property should not be used
-         */
-        batchSize?: number
     }
 }
 

--- a/packages/hardhat-polkadot-resolc/src/utils.ts
+++ b/packages/hardhat-polkadot-resolc/src/utils.ts
@@ -63,7 +63,7 @@ export function updateDefaultCompilerConfig(solcConfigData: SolcConfigData, reso
                 "*": ["abi"],
             },
         },
-        evmVersion: resolc.settings?.evmVersion || compiler.settings.evmVersion,
+        evmVersion: compiler.settings.evmVersion,
         resolc: resolc,
     }
 
@@ -123,14 +123,6 @@ function extractStandardJSONCommands(config: ResolcConfig, commandArgs: string[]
 
     if (settings.emitDourceDebugInfo) {
         commandArgs.push(`-g`)
-    }
-
-    if (settings.outputDir) {
-        commandArgs.push(`--output-dir=${settings.outputDir}`)
-    }
-
-    if (settings.disableSolcOptimizer) {
-        commandArgs.push(`--disable-solc-optimizer`)
     }
 
     return commandArgs


### PR DESCRIPTION
### Description

Updates the comiler options and types to match the `standard-json` input defined in [`resolc`](https://github.com/paritytech/revive/blob/ed608699af7b7f8a329765ec69b10a7fd4eac604/crates/resolc/src/lib.rs#L211-L217)