### PR TITLE
fix(hardhat-polkadot-resolc): cleanup compiler version warning

### DIFF
--- a/packages/hardhat-polkadot-resolc/src/utils.ts
+++ b/packages/hardhat-polkadot-resolc/src/utils.ts
@@ -68,7 +68,7 @@ export function updateDefaultCompilerConfig(solcConfigData: SolcConfigData, reso
     }
 
     const [major, minor] = getVersionComponents(compiler.version)
-    if (major === 0 && minor < 7 && resolc.compilerSource === "binary") {
+    if (major === 0 && minor < 7) {
         throw new ResolcPluginError(
             `Solidity versions below 0.8.0 are not supported. Trying to use ${compiler.version}`,
         )


### PR DESCRIPTION
### Description
This removes the check for the compiler source from the solidity version warning, since the restriction is applicable to the compiler, independent of whether it's the binary or the npm package.