### PR TITLE
fix(hardhat-polkadot-node): add consensus type to dev node options

### DIFF
--- a/packages/hardhat-polkadot-node/src/types.ts
+++ b/packages/hardhat-polkadot-node/src/types.ts
@@ -16,6 +16,7 @@ export interface NodeConfig {
     nodeBinaryPath?: string
     rpcPort?: number
     dev?: boolean
+    consensus?: Consensus
 }
 
 export interface AdapterConfig {
@@ -44,4 +45,9 @@ export interface RpcServer {
 export interface SplitCommands {
     nodeCommands: string[]
     adapterCommands?: string[]
+}
+
+export interface Consensus {
+    seal?: "Instant" | "Manual" | "None"
+    period?: string | number
 }

--- a/packages/hardhat-polkadot-node/src/utils.ts
+++ b/packages/hardhat-polkadot-node/src/utils.ts
@@ -125,6 +125,18 @@ export function constructCommandArgs(
             )
         }
 
+        if (args.nodeCommands?.nodeBinaryPath && args.nodeCommands?.consensus) {
+            if (args.nodeCommands.consensus.seal === "Manual") {
+                nodeCommands.push(
+                    `--consensus=manual-seal-${args.nodeCommands.consensus.period || 50}`,
+                )
+            } else {
+                nodeCommands.push(
+                    `--consensus=${(args.nodeCommands.consensus.seal || "None").toLowerCase()}`,
+                )
+            }
+        }
+
         if (
             args.nodeCommands?.nodeBinaryPath &&
             args.nodeCommands.dev &&


### PR DESCRIPTION
### Description

There's been a break in the `revive-dev-node` that's causing instant seal to not produce any blocks. This PR adds the option to define other types of consensus to work around this.

An example would be:
```ts
const config: HardhatUserConfig = {
    solidity: "0.8.30",
    networks: {
        hardhat: {
            polkavm: true,
            nodeConfig: {
                nodeBinaryPath: "path/to/substrate-node/binary",
                rpcPort: 8000,
                dev: true,
                consensus: {
                    seal: "Manual",
                    period: 50,
            },
            adapterConfig: {
                adapterBinaryPath: "path/to/eth-rpc-adapter",
                dev: true,
            },
        },
    },
    resolc: {
        compilerSource: "binary",
        settings: {
            optimizer: {
                enabled: true,
            },
            compilerPath: "path/to/resolc",
        },
    },
}
```