### PR TITLE
chore: release hotfix

### DIFF
--- a/packages/hardhat-polkadot-node/CHANGELOG.md
+++ b/packages/hardhat-polkadot-node/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## 0.1.3-p0 (2025-07-14)
+### Bug fixes
+
+- Add consensus type to dev node options. ([#228](https://github.com/paritytech/hardhat-polkadot/pull/228)) ([d0846cd](https://github.com/paritytech/hardhat-polkadot/commit/d0846cd2feef66232f7e97d1adffaccb55d4ec58))
+- Fix rpc param when using chopsticks. ([#225](https://github.com/paritytech/hardhat-polkadot/pull/225)) ([512bc2e](https://github.com/paritytech/hardhat-polkadot/commit/512bc2e9d158ee77268f01d6cb90851724195d64))
+
+
 ## 0.1.3 (2025-06-24)
 ### Bug fixes
 

--- a/packages/hardhat-polkadot-node/package.json
+++ b/packages/hardhat-polkadot-node/package.json
@@ -2,7 +2,7 @@
   "name": "@parity/hardhat-polkadot-node",
   "author": "Parity Technologies <admin@parity.io>",
   "license": "AGPL-3.0",
-  "version": "0.1.3",
+  "version": "0.1.3-p0",
   "bugs": "https://github.com/paritytech/hardhat-polkadot/issues",
   "homepage": "https://github.com/paritytech/hardhat-polkadot/tree/master/packages/hardhat-polkadot-node#readme",
   "repository": {

--- a/packages/hardhat-polkadot/CHANGELOG.md
+++ b/packages/hardhat-polkadot/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## 0.1.8-p0 (2025-07-14)
+### Bug fixes
+
+- Fix testnet url. ([#226](https://github.com/paritytech/hardhat-polkadot/pull/226)) ([c9da20c](https://github.com/paritytech/hardhat-polkadot/commit/c9da20cecc146dd2e5052b2877c1c965f82e0a83))
+
+### Internal
+
+- Bumped `@parity/hardhat-polkadot-node` to `0.1.3-p0`.
+
+
 ## 0.1.8 (2025-07-04)
 ### Internal
 

--- a/packages/hardhat-polkadot/package.json
+++ b/packages/hardhat-polkadot/package.json
@@ -2,7 +2,7 @@
     "name": "@parity/hardhat-polkadot",
     "author": "Parity Technologies <admin@parity.io>",
     "license": "AGPL-3.0",
-    "version": "0.1.8",
+    "version": "0.1.8-p0",
     "bugs": "https://github.com/paritytech/hardhat-polkadot/issues",
     "homepage": "https://github.com/paritytech/hardhat-polkadot/tree/master/packages/hardhat-polkadot#readme",
     "repository": {


### PR DESCRIPTION
### Description
This is a hotfix to add a workaround the dev node not producing blocks when `consensus=instant-seal`