### PR TITLE
fix(hardhat-polkadot-resolc): fix resolc default

### DIFF
--- a/packages/hardhat-polkadot-resolc/src/index.ts
+++ b/packages/hardhat-polkadot-resolc/src/index.ts
@@ -54,7 +54,7 @@ const logDebug = debug("hardhat:core:tasks:compile")
 extendConfig((config, userConfig) => {
     if (!config.networks.hardhat.polkavm) return
 
-    const isBinary = config.resolc?.compilerSource === "binary" || undefined
+    const isBinary = config.resolc?.compilerSource === "binary" || !config.resolc.compilerSource;
     const defaultConfig = isBinary ? defaultBinaryResolcConfig : defaultNpmResolcConfig
     const customConfig = userConfig?.resolc || {}
 

--- a/packages/hardhat-polkadot-resolc/src/index.ts
+++ b/packages/hardhat-polkadot-resolc/src/index.ts
@@ -54,7 +54,7 @@ const logDebug = debug("hardhat:core:tasks:compile")
 extendConfig((config, userConfig) => {
     if (!config.networks.hardhat.polkavm) return
 
-    const isBinary = config.resolc?.compilerSource === "binary" || !config.resolc.compilerSource
+    const isBinary = config.resolc?.compilerSource === "binary" || !config.resolc?.compilerSource
     const defaultConfig = isBinary ? defaultBinaryResolcConfig : defaultNpmResolcConfig
     const customConfig = userConfig?.resolc || {}
 

--- a/packages/hardhat-polkadot-resolc/src/index.ts
+++ b/packages/hardhat-polkadot-resolc/src/index.ts
@@ -54,7 +54,7 @@ const logDebug = debug("hardhat:core:tasks:compile")
 extendConfig((config, userConfig) => {
     if (!config.networks.hardhat.polkavm) return
 
-    const isBinary = config.resolc?.compilerSource === "binary" || !config.resolc.compilerSource;
+    const isBinary = config.resolc?.compilerSource === "binary" || !config.resolc.compilerSource
     const defaultConfig = isBinary ? defaultBinaryResolcConfig : defaultNpmResolcConfig
     const customConfig = userConfig?.resolc || {}
 


### PR DESCRIPTION
### Description
Now without specifying the `compilerSource` inside of `resolc`, it defaults to the binary default configuration.