### PR TITLE
fix(hardhat-polkadot-resolc): flip default check

### DIFF
--- a/packages/hardhat-polkadot-resolc/src/index.ts
+++ b/packages/hardhat-polkadot-resolc/src/index.ts
@@ -54,8 +54,10 @@ const logDebug = debug("hardhat:core:tasks:compile")
 extendConfig((config, userConfig) => {
     if (!config.networks.hardhat.polkavm) return
 
-    const isBinary = config.resolc?.compilerSource === "binary" || !config.resolc?.compilerSource
-    const defaultConfig = isBinary ? defaultBinaryResolcConfig : defaultNpmResolcConfig
+    // We check for `npm` as `compilerSource`, because for every other case
+    // we prefer using the binary.
+    const isNpm = config.resolc?.compilerSource === "npm"
+    const defaultConfig = isNpm ? defaultNpmResolcConfig : defaultBinaryResolcConfig
     const customConfig = userConfig?.resolc || {}
 
     const optimizer = Object.assign(


### PR DESCRIPTION
### Description
This flips the check so instead of checking if the `binary` was selected, we check if `npm` is selected, and for every other choice we just default to the binary.