### PR TITLE
fix(deps): resolve micro-eth-signer to 0.16.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,5 +24,8 @@
     "prettier": "^3.3.0",
     "typescript": "^5.8.3"
   },
-  "packageManager": "pnpm@9.3.0"
+  "packageManager": "pnpm@9.3.0",
+  "resolutions": {
+    "micro-eth-signer": "0.16.0"
+  }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4,6 +4,9 @@ settings:
   autoInstallPeers: true
   excludeLinksFromLockfile: false
 
+overrides:
+  micro-eth-signer: 0.16.0
+
 importers:
 
   .:


### PR DESCRIPTION
### Description

This resolves `micro-eth-signer` to 0.16.0 to keep the fix detailed [here](https://github.com/NomicFoundation/hardhat/issues/6950#issue-3189814970) that was then backtracked by hardhat.