### PR TITLE
fix: update substrate-node to dev-node

### DIFF
--- a/examples/all-polkavm-networks/hardhat.config.ts
+++ b/examples/all-polkavm-networks/hardhat.config.ts
@@ -11,7 +11,7 @@ const config: HardhatUserConfig = {
         hardhat: {
             polkavm: true,
             nodeConfig: {
-                nodeBinaryPath: "./bin/substrate-node",
+                nodeBinaryPath: "./bin/dev-node",
                 rpcPort: 8000,
                 dev: true,
             },

--- a/examples/localNode.config.ts
+++ b/examples/localNode.config.ts
@@ -7,7 +7,7 @@ const config: HardhatUserConfig = {
         hardhat: {
             polkavm: true,
             nodeConfig: {
-                nodeBinaryPath: "path/to/substrate-node/binary",
+                nodeBinaryPath: "path/to/dev-node/binary",
                 rpcPort: 8000,
                 dev: true,
             },

--- a/packages/hardhat-polkadot/sample-projects/typescript/README.md
+++ b/packages/hardhat-polkadot/sample-projects/typescript/README.md
@@ -2,7 +2,7 @@
 
 This project demonstrates how to use Hardhat with Polkadot. It comes with a sample contract, a test for that contract, and a Hardhat Ignition module that deploys that contract.
 
-1) Create a binary of the [`eth-rpc`](https://github.com/paritytech/polkadot-sdk/tree/master/substrate/frame/revive/rpc) and the `substrate-node` and move them to the `bin` folder at the root of your project. Alternatively, update your configuration file to point to your local binary. For instructions, check [Polkadot Hardhat docs](https://docs.polkadot.com/develop/smart-contracts/dev-environments/hardhat/#test-your-contract).
+1) Create a binary of the [`eth-rpc`](https://github.com/paritytech/polkadot-sdk/tree/master/substrate/frame/revive/rpc) and the `dev-node` and move them to the `bin` folder at the root of your project. Alternatively, update your configuration file to point to your local binary. For instructions, check [Polkadot Hardhat docs](https://docs.polkadot.com/develop/smart-contracts/dev-environments/hardhat/#test-your-contract).
 
 2) Try running some of the following tasks:
 

--- a/packages/hardhat-polkadot/sample-projects/typescript/hardhat.config.ts
+++ b/packages/hardhat-polkadot/sample-projects/typescript/hardhat.config.ts
@@ -8,7 +8,7 @@ const config: HardhatUserConfig = {
         hardhat: {
             polkavm: true,
             nodeConfig: {
-                nodeBinaryPath: "./bin/substrate-node",
+                nodeBinaryPath: "./bin/dev-node",
                 rpcPort: 8000,
                 dev: true,
             },

--- a/packages/hardhat-polkadot/src/cli/project-creation.ts
+++ b/packages/hardhat-polkadot/src/cli/project-creation.ts
@@ -228,7 +228,7 @@ module.exports = {
         hardhat: {
             polkavm: true,
             nodeConfig: {
-                nodeBinaryPath: './bin/substrate-node',
+                nodeBinaryPath: './bin/dev-node',
                 dev: true,
                 rpcPort: 8000
             },


### PR DESCRIPTION
# Description

* Closes #271 
* Since we will now be using the revive-dev-node, we should rename it to avoid any confusion.