### PR TITLE
fix(hardhat-polkadot-node): rename to work with network helpers

### DIFF
--- a/packages/hardhat-polkadot-node/src/constants.ts
+++ b/packages/hardhat-polkadot-node/src/constants.ts
@@ -14,7 +14,7 @@ export const PORT_CHECK_DELAY = 500
 export const RPC_ENDPOINT_PATH = "eth_chainId"
 export const NODE_RPC_URL_BASE_URL = process.env.CI ? "0.0.0.0" : "host.docker.internal"
 
-export const POLKADOT_TEST_NODE_NETWORK_NAME = "Kitchensink"
+export const POLKADOT_TEST_NODE_NETWORK_NAME = "anvil"
 
 export const BASE_URL = "http://127.0.0.1"
 export const POLKADOT_NETWORK_ACCOUNTS = [

--- a/packages/hardhat-polkadot-node/src/utils.ts
+++ b/packages/hardhat-polkadot-node/src/utils.ts
@@ -14,7 +14,6 @@ import { PolkadotNodePluginError } from "./errors"
 import {
     BASE_URL,
     MAX_PORT_ATTEMPTS,
-    POLKADOT_NETWORK_ACCOUNTS,
     NETWORK_ETH,
     NETWORK_GAS,
     NETWORK_GAS_PRICE,

--- a/packages/hardhat-polkadot-node/src/utils.ts
+++ b/packages/hardhat-polkadot-node/src/utils.ts
@@ -203,7 +203,7 @@ export function adjustTaskArgsForPort(taskArgs: string[], currentPort: number): 
 
 export function getNetworkConfig(url: string, chainId?: number) {
     return {
-        accounts: POLKADOT_NETWORK_ACCOUNTS,
+        accounts: "remote",
         gas: NETWORK_GAS.AUTO,
         gasPrice: NETWORK_GAS_PRICE.AUTO,
         gasMultiplier: 1,


### PR DESCRIPTION
### Description
This renames the node to `anvil` so that it works with the hardhat network helpers. It also makes it pull the accounts from the node instead of using the local hardcoded ones.