### PR TITLE
fix: removing `bundledDependencies`

### DIFF
--- a/packages/hardhat-polkadot/.npmrc
+++ b/packages/hardhat-polkadot/.npmrc
@@ -1,1 +1,0 @@
-node-linker=hoisted

--- a/packages/hardhat-polkadot/package.json
+++ b/packages/hardhat-polkadot/package.json
@@ -53,8 +53,8 @@
     ],
     "dependencies": {
         "@openzeppelin/contracts": "^5.3.0",
-        "@parity/hardhat-polkadot-node": "workspace:^",
-        "@parity/hardhat-polkadot-resolc": "workspace:^",
+        "@parity/hardhat-polkadot-node": "workspace:*",
+        "@parity/hardhat-polkadot-resolc": "workspace:*",
         "enquirer": "2.3.0",
         "find-up": "5.0.0",
         "fs-extra": "^11.3.0",

--- a/packages/hardhat-polkadot/package.json
+++ b/packages/hardhat-polkadot/package.json
@@ -63,10 +63,6 @@
     "peerDependencies": {
         "hardhat": "^2.26.0"
     },
-    "bundledDependencies": [
-        "@parity/hardhat-polkadot-node",
-        "@parity/hardhat-polkadot-resolc"
-    ],
     "devDependencies": {
         "@eslint/js": "^9.30.1",
         "@nomicfoundation/hardhat-ignition": "^0.15.11",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -30,10 +30,10 @@ importers:
         specifier: ^5.3.0
         version: 5.3.0
       '@parity/hardhat-polkadot-node':
-        specifier: workspace:^
+        specifier: workspace:*
         version: link:../hardhat-polkadot-node
       '@parity/hardhat-polkadot-resolc':
-        specifier: workspace:^
+        specifier: workspace:*
         version: link:../hardhat-polkadot-resolc
       enquirer:
         specifier: 2.3.0


### PR DESCRIPTION
Both `npm` and `pnpm` behave buggy with these, skipping their
dependencies.
Then, because smart contract project will probably have some versions of
ethers or lru-cache, we're getting errors like these:
```
TypeError: lru_cache_1.LRUCache is not a constructor
```

As `@parity/hardhat-polkadot-node` and `@parity/hardhat-polkadot-resolc`
are in dependencies or `@parity/hardhat-polkadot`, they will be
installed automatically.

Do these serve the purpose of eased local development?
