### PR TITLE
fix(hardhat-polkadot-node): spin up an archive node.

### DIFF
--- a/packages/hardhat-polkadot-node/CHANGELOG.md
+++ b/packages/hardhat-polkadot-node/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## 0.1.5 (2025-08-13)
+### Bug fixes
+
+- Rename node to `anvil` to work with network helpers. ([#273](https://github.com/paritytech/hardhat-polkadot/pull/273)) ([79d2504](https://github.com/paritytech/hardhat-polkadot/commit/79d2504a7aa77dca9985b22bb2e16b46317dfbd8))
+- Support deploying factory contracts. ([#256](https://github.com/paritytech/hardhat-polkadot/pull/256)) ([c995b32](https://github.com/paritytech/hardhat-polkadot/commit/c995b32784802c90fc4ce617854608bb6d224be5))
+- Enable polkavm when not set in default Hardhat network. ([#253](https://github.com/paritytech/hardhat-polkadot/pull/253)) ([0f33d17](https://github.com/paritytech/hardhat-polkadot/commit/0f33d171ff353d3aced247759853f8a5939678b2))
+- Create applications as a combination of services ([#248](https://github.com/paritytech/hardhat-polkadot/pull/248)) ([dea3516](https://github.com/paritytech/hardhat-polkadot/commit/dea351652dd9eeeed427dbf9ff4b74e815bdc315))
+
+
 ## 0.1.4 (2025-07-22)
 ### Bug fixes
 

--- a/packages/hardhat-polkadot-node/package.json
+++ b/packages/hardhat-polkadot-node/package.json
@@ -2,7 +2,7 @@
   "name": "@parity/hardhat-polkadot-node",
   "author": "Parity Technologies <admin@parity.io>",
   "license": "AGPL-3.0",
-  "version": "0.1.4",
+  "version": "0.1.5",
   "bugs": "https://github.com/paritytech/hardhat-polkadot/issues",
   "homepage": "https://github.com/paritytech/hardhat-polkadot/tree/master/packages/hardhat-polkadot-node#readme",
   "repository": {

--- a/packages/hardhat-polkadot-node/src/utils.ts
+++ b/packages/hardhat-polkadot-node/src/utils.ts
@@ -149,6 +149,8 @@ export function constructCommandArgs(
         }
     }
 
+    nodeCommands.push(`--pruning=archive`)
+
     return {
         nodeCommands,
         adapterCommands,

--- a/packages/hardhat-polkadot-resolc/CHANGELOG.md
+++ b/packages/hardhat-polkadot-resolc/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Changelog
 
+## 0.1.8 (2025-08-13)
+### Bug Fixes
+
+- Enable polkavm when not set in default Hardhat network. ([#253](https://github.com/paritytech/hardhat-polkadot/pull/253)) ([0f33d17](https://github.com/paritytech/hardhat-polkadot/commit/0f33d171ff353d3aced247759853f8a5939678b2))
+- Flip default `resolc`check to check for `npm` instead of `binary`. ([#247](https://github.com/paritytech/hardhat-polkadot/pull/247)) ([30b441f](https://github.com/paritytech/hardhat-polkadot/commit/30b441f27ad14056dced88d038d5eaa016594de0))
+- Fix default `resolc` config to default to `binary` instead of `npm`. ([#246](https://github.com/paritytech/hardhat-polkadot/pull/246)) ([eed3acc](https://github.com/paritytech/hardhat-polkadot/commit/eed3accc25918a988845072a981f9a0c868e3324))
+
+### Chores
+
+- Bump `@parity/resolc` to 0.3.0. ([#216](https://github.com/paritytech/hardhat-polkadot/pull/216)) ([20cd285](https://github.com/paritytech/hardhat-polkadot/commit/20cd285a3d9d64356294038153e518e38a63f0d7))
+
 ## 0.1.7 (2025-07-22)
 ### Chores
 

--- a/packages/hardhat-polkadot-resolc/package.json
+++ b/packages/hardhat-polkadot-resolc/package.json
@@ -2,7 +2,7 @@
   "name": "@parity/hardhat-polkadot-resolc",
   "author": "Parity Technologies <admin@parity.io>",
   "license": "AGPL-3.0",
-  "version": "0.1.7",
+  "version": "0.1.8",
   "bugs": "https://github.com/paritytech/hardhat-polkadot/issues",
   "homepage": "https://github.com/paritytech/hardhat-polkadot/tree/master/packages/hardhat-polkadot-resolc#readme",
   "repository": {

--- a/packages/hardhat-polkadot/CHANGELOG.md
+++ b/packages/hardhat-polkadot/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Changelog
 
+## 0.1.10 (2025-08-13)
+### Chores
+
+- Resolve micro-eth-signer to 0.16.0. ([#270](https://github.com/paritytech/hardhat-polkadot/pull/270)) ([9b97254](https://github.com/paritytech/hardhat-polkadot/commit/9b972541aff4fc51ae206d0754f9ffea8669077e))
+- Add a -y flag to the init process. Serve a hardhat config that has all the endpoints already configured. ([#262](https://github.com/paritytech/hardhat-polkadot/pull/262)) ([a8cad65](https://github.com/paritytech/hardhat-polkadot/commit/a8cad6506c1019759e7e5565cdb4b976d233d20c))
+
+### Internal
+
+- Bumped `@parity/hardhat-polkadot-resolc` to `0.1.8`.
+- Bumped `@parity/hardhat-polkadot-node` to `0.1.5`.
+
+
 ## 0.1.9 (2025-07-22)
 ### Internal
 

--- a/packages/hardhat-polkadot/package.json
+++ b/packages/hardhat-polkadot/package.json
@@ -2,7 +2,7 @@
     "name": "@parity/hardhat-polkadot",
     "author": "Parity Technologies <admin@parity.io>",
     "license": "AGPL-3.0",
-    "version": "0.1.9",
+    "version": "0.1.10",
     "bugs": "https://github.com/paritytech/hardhat-polkadot/issues",
     "homepage": "https://github.com/paritytech/hardhat-polkadot/tree/master/packages/hardhat-polkadot#readme",
     "repository": {


### PR DESCRIPTION
### Description
In order to have `snapshot`. `reset` and `revert` work with our node, we need it to be an archive node. This adds this flag when starting the node.