### PR TITLE
fix(hardhat-polkadot-node): spin up an archive node

### DIFF
--- a/packages/hardhat-polkadot-node/src/utils.ts
+++ b/packages/hardhat-polkadot-node/src/utils.ts
@@ -149,6 +149,8 @@ export function constructCommandArgs(
         }
     }
 
+    nodeCommands.push(`--pruning=archive`)
+
     return {
         nodeCommands,
         adapterCommands,


### PR DESCRIPTION
### Description
In order to have `snapshot`, `reset` and `revert` work with our node, we need it to be an archive node. This adds this flag when starting the node.