### PR TITLE
fix: fixing tests; adding verbosity

### DIFF
--- a/packages/hardhat-polkadot-node/src/services/chopsticks.ts
+++ b/packages/hardhat-polkadot-node/src/services/chopsticks.ts
@@ -26,6 +26,7 @@ export class ChopsticksService extends Service {
 
             let stdioConfig: StdioOptions = "inherit"
             if (!this.blockProcess) {
+                // FIXME: this leads to silent failures
                 stdioConfig = ["ignore", "ignore", "ignore"]
             }
 

--- a/packages/hardhat-polkadot-node/src/utils.ts
+++ b/packages/hardhat-polkadot-node/src/utils.ts
@@ -149,7 +149,10 @@ export function constructCommandArgs(
         }
     }
 
-    nodeCommands.push(`--pruning=archive`)
+    // TODO: revisit this condition, possibly merge with something from above
+    if (!args?.forking) {
+        nodeCommands.push(`--pruning=archive`)
+    }
 
     return {
         nodeCommands,
@@ -360,7 +363,9 @@ export async function waitForServiceToBeReady(
         waitTime = Math.min(waitTime * backoffFactor, maxWaitTime)
     }
 
-    throw new PolkadotNodePluginError("Server didn't respond after multiple attempts")
+    throw new PolkadotNodePluginError(
+        `Server at port ${port} didn't respond after multiple attempts`,
+    )
 }
 
 export function getPolkadotRpcUrl(

--- a/tests/e2e/1-test-in-memory.test.sh
+++ b/tests/e2e/1-test-in-memory.test.sh
@@ -9,13 +9,17 @@ run_test() {
   CONFIG_FILE=$2
   EXPECTED_PASSING=$3
   NETWORK_NAME=$4
+  echo "Running test in fixture-projects/$PROJECT_DIR for ${CONFIG_FILE}; network ${NETWORK_NAME}"
+
   cd "$TMP_TESTS_DIR/$PROJECT_DIR"
+  npm add "$HARDHAT_POLKADOT_NODE_TGZ_PATH"
+  npm add "$HARDHAT_POLKADOT_RESOLC_TGZ_PATH"
   npm add "$HARDHAT_POLKADOT_TGZ_PATH"
   npm install
   cp "../$CONFIG_FILE" ./hardhat.config.js
 
   # When
-  RUN_TESTS_OUTPUT=$(npx hardhat test)
+  RUN_TESTS_OUTPUT="$(npx hardhat test --show-stack-traces)"
 
   # Then
   assert_directory_not_empty "artifacts-pvm"

--- a/tests/e2e/2-deploy-in-node.test.sh
+++ b/tests/e2e/2-deploy-in-node.test.sh
@@ -6,7 +6,9 @@ set -e # Fail if any command fails
 # Given
 cp ./basic-test-and-deploy.config.js ./lock/hardhat.config.js
 cd ./lock # relative to tmp folder
-npm add $HARDHAT_POLKADOT_TGZ_PATH
+npm add "$HARDHAT_POLKADOT_NODE_TGZ_PATH"
+npm add "$HARDHAT_POLKADOT_RESOLC_TGZ_PATH"
+npm add "$HARDHAT_POLKADOT_TGZ_PATH"
 npm install # install modules specified in the package.json
 lsof -ti tcp:8000 | xargs -r kill -9
 npx hardhat node > hardhat-node.log 2>&1 & # Start the Hardhat node in the background

--- a/tests/run.sh
+++ b/tests/run.sh
@@ -11,11 +11,22 @@ case "$TESTS_TYPE" in
   *) echo "Unknown test type: $TESTS_TYPE" >&2; exit 1 ;;
 esac
 
-# 2) build and export packages/hardhat-polkadot
+# 2) build and export packages/hardhat-polkadot, packages/hardhat-polkadot-node and packages/hardhat-polkadot-resolc
 cd ..
 pnpm install
-pnpm run build
-cd ./packages/hardhat-polkadot
+pnpm run -r build
+
+cd ./packages/hardhat-polkadot-node
+HARDHAT_POLKADOT_NODE_TGZ=$(pnpm pack --silent | grep "parity-hardhat-polkadot-node-*.*.*.tgz")
+export HARDHAT_POLKADOT_NODE_TGZ_PATH="$(pwd)/$HARDHAT_POLKADOT_NODE_TGZ"
+cd ../../tests >/dev/null
+
+cd ../packages/hardhat-polkadot-resolc
+HARDHAT_POLKADOT_RESOLC_TGZ=$(pnpm pack --silent | grep "parity-hardhat-polkadot-resolc-*.*.*.tgz")
+export HARDHAT_POLKADOT_RESOLC_TGZ_PATH="$(pwd)/$HARDHAT_POLKADOT_RESOLC_TGZ"
+cd ../../tests >/dev/null
+
+cd ../packages/hardhat-polkadot
 ./prepack.sh # run prepack script
 HARDHAT_POLKADOT_TGZ=$(pnpm pack --silent | grep "parity-hardhat-polkadot-*.*.*.tgz")
 export HARDHAT_POLKADOT_TGZ_PATH="$(pwd)/$HARDHAT_POLKADOT_TGZ"
@@ -24,13 +35,16 @@ cd ../../tests >/dev/null
 # 3) create a temporary directory to run the tests
 TMP_DIR=$(mktemp -d -t hardhat-polkadot.XXXXXXX)
 export TMP_TESTS_DIR="${TMP_DIR}/run-$(date +%Y-%m-%d-%H-%M-%S)"
-cp -r fixture-projects $TMP_TESTS_DIR
-cp helpers.sh $TMP_TESTS_DIR/helpers.sh  # copy the helper script
+cp -r fixture-projects "$TMP_TESTS_DIR"
+cp helpers.sh "$TMP_TESTS_DIR/helpers.sh"  # copy the helper script
 
 # 4) print relevant info
-printf "Package manager version: npm version $(npm --version)\n"
-printf "@parity/hardhat-polkadot package in $HARDHAT_POLKADOT_TGZ_PATH\n"
-printf "Running tests in $TMP_TESTS_DIR\n\n"
+echo "Package manager version: npm version $(npm --version)"
+echo "@parity/hardhat-polkadot-node package in $HARDHAT_POLKADOT_NODE_TGZ_PATH"
+echo "@parity/hardhat-polkadot-resolc package in $HARDHAT_POLKADOT_HARDHAT_POLKADOT_RESOLC_TGZ_PATH"
+echo "@parity/hardhat-polkadot package in $HARDHAT_POLKADOT_TGZ_PATH"
+echo "Running tests in $TMP_TESTS_DIR"
+echo
 
 for file in ./$DIR/*; do
     FILE_NAME=$(basename "$file")

--- a/tests/unit/compile-basic.test.sh
+++ b/tests/unit/compile-basic.test.sh
@@ -6,7 +6,9 @@ set -e # Fail if any command fails
 # Given
 cp ./basic-compile.config.js ./foo/hardhat.config.js # relative to tmp folder
 cd ./foo # relative to tmp folder
-npm add $HARDHAT_POLKADOT_TGZ_PATH
+npm add "$HARDHAT_POLKADOT_NODE_TGZ_PATH"
+npm add "$HARDHAT_POLKADOT_RESOLC_TGZ_PATH"
+npm add "$HARDHAT_POLKADOT_TGZ_PATH"
 npm install # install modules specified in the package.json
 
 # When

--- a/tests/unit/compile-multiple.test.sh
+++ b/tests/unit/compile-multiple.test.sh
@@ -6,7 +6,9 @@ set -e # Fail if any command fails
 # Given
 cp ./multiple-compile.config.js ./foo/hardhat.config.js # relative to tmp folder
 cd ./foo # relative to tmp folder
-npm add $HARDHAT_POLKADOT_TGZ_PATH
+npm add "$HARDHAT_POLKADOT_NODE_TGZ_PATH"
+npm add "$HARDHAT_POLKADOT_RESOLC_TGZ_PATH"
+npm add "$HARDHAT_POLKADOT_TGZ_PATH"
 npm install # install modules specified in the package.json
 
 # When/Then


### PR DESCRIPTION
Two different reasons for broken tests:
1. After removal of `bundledDependencies`,
`@parity/hardhat-polkadot-node` and `-resolc` weren't installed to the
test setup; however, as we haven't done a version bump yet, they got
installed as dependencies from npm registry.
This led to green tests in my PR, before I've attempted to do bump
version.
Thus, added separate install of those packages.
I've also added some string quoting in shell scripts while I'm touching
that

2. #286 has introduced another issue, which wasn't caught by the tests
due to the false-positive described in point 1.
The issue is that the added `--pruning=archive` argument was also
applied to chopsticks, but only intended for substrate node.
Also changed the logging a bit, so we'd at least know which server
doesn't get up
