### PR TITLE
fix(hardhat-polkadot): Replace npm references with pnpm 

### DIFF
--- a/packages/hardhat-polkadot-resolc/src/compile/npm.ts
+++ b/packages/hardhat-polkadot-resolc/src/compile/npm.ts
@@ -54,7 +54,7 @@ export function updateSolc(version: string) {
 
     if (!currentVersion || !semver.satisfies(currentVersion, version)) {
         try {
-            execSync(`npm install --save-dev --save-exact solc@${version} --quiet`, {
+            execSync(`pnpm install --save-dev --save-exact solc@${version} --quiet`, {
                 stdio: "inherit",
             })
         } catch (error) {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -30,11 +30,11 @@ importers:
         specifier: ^5.3.0
         version: 5.3.0
       '@parity/hardhat-polkadot-node':
-        specifier: workspace:*
-        version: link:../hardhat-polkadot-node
+        specifier: '*'
+        version: 0.1.6-pre1(@types/node@22.15.24)(hardhat@2.26.0(ts-node@10.9.2(@types/node@22.15.24)(typescript@5.8.3))(typescript@5.8.3))(rxjs@7.8.2)(typescript@5.8.3)
       '@parity/hardhat-polkadot-resolc':
-        specifier: workspace:*
-        version: link:../hardhat-polkadot-resolc
+        specifier: '*'
+        version: 0.1.9-pre0(@types/node@22.15.24)(hardhat@2.26.0(ts-node@10.9.2(@types/node@22.15.24)(typescript@5.8.3))(typescript@5.8.3))(typescript@5.8.3)
       enquirer:
         specifier: 2.3.0
         version: 2.3.0
@@ -733,6 +733,16 @@ packages:
 
   '@openzeppelin/contracts@5.3.0':
     resolution: {integrity: sha512-zj/KGoW7zxWUE8qOI++rUM18v+VeLTTzKs/DJFkSzHpQFPD/jKKF0TrMxBfGLl3kpdELCNccvB3zmofSzm4nlA==}
+
+  '@parity/hardhat-polkadot-node@0.1.6-pre1':
+    resolution: {integrity: sha512-Wy45cEAvZI+kdKqCKnpBVJaG79S14BVh9/lkehW06o5yX94gc2osIDpb1lwB7tVsDTONiqj/UEjehBUya/5mDQ==}
+    peerDependencies:
+      hardhat: ^2.26.0
+
+  '@parity/hardhat-polkadot-resolc@0.1.9-pre0':
+    resolution: {integrity: sha512-Wm3VQ9g4pa14zHqADEuoOjUub8p/Hy8FG23+PHUccWfg4aBB2ZwEWEcc30+e6q6dDZoYs9bNdcXYjQwBliPxow==}
+    peerDependencies:
+      hardhat: ^2.26.0
 
   '@parity/resolc@0.3.0':
     resolution: {integrity: sha512-vWaKhqM89YH+Kn1y+0Kv92NG+0G7HktDhA3OdYvCoG320R4djpg/N/C9s90w/B0IWrRfaGR3Nk3R6O+VOBMjFA==}
@@ -3934,6 +3944,55 @@ snapshots:
       '@nomicfoundation/solidity-analyzer-win32-x64-msvc': 0.1.2
 
   '@openzeppelin/contracts@5.3.0': {}
+
+  '@parity/hardhat-polkadot-node@0.1.6-pre1(@types/node@22.15.24)(hardhat@2.26.0(ts-node@10.9.2(@types/node@22.15.24)(typescript@5.8.3))(typescript@5.8.3))(rxjs@7.8.2)(typescript@5.8.3)':
+    dependencies:
+      axios: 1.9.0(debug@4.4.1)
+      chalk: 4.1.2
+      debug: 4.4.1(supports-color@8.1.1)
+      dockerode: 4.0.6
+      ethers: 6.15.0
+      fast-glob: 3.3.3
+      hardhat: 2.26.0(ts-node@10.9.2(@types/node@22.15.24)(typescript@5.8.3))(typescript@5.8.3)
+      lru-cache: 11.1.0
+      polkadot-api: 1.15.2(rxjs@7.8.2)
+      run-container: 2.0.12
+      source-map-support: 0.5.21
+      ts-node: 10.9.2(@types/node@22.15.24)(typescript@5.8.3)
+    transitivePeerDependencies:
+      - '@microsoft/api-extractor'
+      - '@swc/core'
+      - '@swc/wasm'
+      - '@types/node'
+      - bufferutil
+      - jiti
+      - postcss
+      - rxjs
+      - supports-color
+      - tsx
+      - typescript
+      - utf-8-validate
+      - yaml
+
+  '@parity/hardhat-polkadot-resolc@0.1.9-pre0(@types/node@22.15.24)(hardhat@2.26.0(ts-node@10.9.2(@types/node@22.15.24)(typescript@5.8.3))(typescript@5.8.3))(typescript@5.8.3)':
+    dependencies:
+      '@ethereumjs/util': 10.0.0
+      '@parity/resolc': 0.3.0(debug@4.4.1)
+      axios: 1.9.0(debug@4.4.1)
+      chalk: 4.1.2
+      debug: 4.4.1(supports-color@8.1.1)
+      find-up: 5.0.0
+      fs-extra: 11.3.0
+      fs-xattr: 0.4.0
+      hardhat: 2.26.0(ts-node@10.9.2(@types/node@22.15.24)(typescript@5.8.3))(typescript@5.8.3)
+      semver: 7.7.2
+      ts-node: 10.9.2(@types/node@22.15.24)(typescript@5.8.3)
+    transitivePeerDependencies:
+      - '@swc/core'
+      - '@swc/wasm'
+      - '@types/node'
+      - supports-color
+      - typescript
 
   '@parity/resolc@0.3.0(debug@4.4.1)':
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -30,11 +30,11 @@ importers:
         specifier: ^5.3.0
         version: 5.3.0
       '@parity/hardhat-polkadot-node':
-        specifier: '*'
-        version: 0.1.6-pre1(@types/node@22.15.24)(hardhat@2.26.0(ts-node@10.9.2(@types/node@22.15.24)(typescript@5.8.3))(typescript@5.8.3))(rxjs@7.8.2)(typescript@5.8.3)
+        specifier: workspace:*
+        version: link:../hardhat-polkadot-node
       '@parity/hardhat-polkadot-resolc':
-        specifier: '*'
-        version: 0.1.9-pre0(@types/node@22.15.24)(hardhat@2.26.0(ts-node@10.9.2(@types/node@22.15.24)(typescript@5.8.3))(typescript@5.8.3))(typescript@5.8.3)
+        specifier: workspace:*
+        version: link:../hardhat-polkadot-resolc
       enquirer:
         specifier: 2.3.0
         version: 2.3.0
@@ -119,7 +119,7 @@ importers:
         version: 11.1.0
       polkadot-api:
         specifier: 1.15.2
-        version: 1.15.2(rxjs@7.8.2)
+        version: 1.15.2(rxjs@7.8.2)(yaml@2.8.1)
       run-container:
         specifier: ^2.0.12
         version: 2.0.12
@@ -733,16 +733,6 @@ packages:
 
   '@openzeppelin/contracts@5.3.0':
     resolution: {integrity: sha512-zj/KGoW7zxWUE8qOI++rUM18v+VeLTTzKs/DJFkSzHpQFPD/jKKF0TrMxBfGLl3kpdELCNccvB3zmofSzm4nlA==}
-
-  '@parity/hardhat-polkadot-node@0.1.6-pre1':
-    resolution: {integrity: sha512-Wy45cEAvZI+kdKqCKnpBVJaG79S14BVh9/lkehW06o5yX94gc2osIDpb1lwB7tVsDTONiqj/UEjehBUya/5mDQ==}
-    peerDependencies:
-      hardhat: ^2.26.0
-
-  '@parity/hardhat-polkadot-resolc@0.1.9-pre0':
-    resolution: {integrity: sha512-Wm3VQ9g4pa14zHqADEuoOjUub8p/Hy8FG23+PHUccWfg4aBB2ZwEWEcc30+e6q6dDZoYs9bNdcXYjQwBliPxow==}
-    peerDependencies:
-      hardhat: ^2.26.0
 
   '@parity/resolc@0.3.0':
     resolution: {integrity: sha512-vWaKhqM89YH+Kn1y+0Kv92NG+0G7HktDhA3OdYvCoG320R4djpg/N/C9s90w/B0IWrRfaGR3Nk3R6O+VOBMjFA==}
@@ -3411,6 +3401,11 @@ packages:
     resolution: {integrity: sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==}
     engines: {node: '>=10'}
 
+  yaml@2.8.1:
+    resolution: {integrity: sha512-lcYcMxX2PO9XMGvAJkJ3OsNMw+/7FKes7/hgerGUYWIoWu5j/+YQqcZr5JnPZWzOsEBgMbSbiSTn/dv/69Mkpw==}
+    engines: {node: '>= 14.6'}
+    hasBin: true
+
   yargs-parser@20.2.9:
     resolution: {integrity: sha512-y11nGElTIV+CT3Zv9t7VKl+Q3hTQoT9a1Qzezhhl6Rp21gJ/IVTW7Z3y9EWXhuUBC2Shnf+DX0antecpAwSP8w==}
     engines: {node: '>=10'}
@@ -3945,55 +3940,6 @@ snapshots:
 
   '@openzeppelin/contracts@5.3.0': {}
 
-  '@parity/hardhat-polkadot-node@0.1.6-pre1(@types/node@22.15.24)(hardhat@2.26.0(ts-node@10.9.2(@types/node@22.15.24)(typescript@5.8.3))(typescript@5.8.3))(rxjs@7.8.2)(typescript@5.8.3)':
-    dependencies:
-      axios: 1.9.0(debug@4.4.1)
-      chalk: 4.1.2
-      debug: 4.4.1(supports-color@8.1.1)
-      dockerode: 4.0.6
-      ethers: 6.15.0
-      fast-glob: 3.3.3
-      hardhat: 2.26.0(ts-node@10.9.2(@types/node@22.15.24)(typescript@5.8.3))(typescript@5.8.3)
-      lru-cache: 11.1.0
-      polkadot-api: 1.15.2(rxjs@7.8.2)
-      run-container: 2.0.12
-      source-map-support: 0.5.21
-      ts-node: 10.9.2(@types/node@22.15.24)(typescript@5.8.3)
-    transitivePeerDependencies:
-      - '@microsoft/api-extractor'
-      - '@swc/core'
-      - '@swc/wasm'
-      - '@types/node'
-      - bufferutil
-      - jiti
-      - postcss
-      - rxjs
-      - supports-color
-      - tsx
-      - typescript
-      - utf-8-validate
-      - yaml
-
-  '@parity/hardhat-polkadot-resolc@0.1.9-pre0(@types/node@22.15.24)(hardhat@2.26.0(ts-node@10.9.2(@types/node@22.15.24)(typescript@5.8.3))(typescript@5.8.3))(typescript@5.8.3)':
-    dependencies:
-      '@ethereumjs/util': 10.0.0
-      '@parity/resolc': 0.3.0(debug@4.4.1)
-      axios: 1.9.0(debug@4.4.1)
-      chalk: 4.1.2
-      debug: 4.4.1(supports-color@8.1.1)
-      find-up: 5.0.0
-      fs-extra: 11.3.0
-      fs-xattr: 0.4.0
-      hardhat: 2.26.0(ts-node@10.9.2(@types/node@22.15.24)(typescript@5.8.3))(typescript@5.8.3)
-      semver: 7.7.2
-      ts-node: 10.9.2(@types/node@22.15.24)(typescript@5.8.3)
-    transitivePeerDependencies:
-      - '@swc/core'
-      - '@swc/wasm'
-      - '@types/node'
-      - supports-color
-      - typescript
-
   '@parity/resolc@0.3.0(debug@4.4.1)':
     dependencies:
       '@types/node': 22.17.0
@@ -4019,7 +3965,7 @@ snapshots:
       '@pnpm/network.ca-file': 1.0.2
       config-chain: 1.1.13
 
-  '@polkadot-api/cli@0.14.4':
+  '@polkadot-api/cli@0.14.4(yaml@2.8.1)':
     dependencies:
       '@commander-js/extra-typings': 14.0.0(commander@14.0.0)
       '@polkadot-api/codegen': 0.17.1
@@ -4044,7 +3990,7 @@ snapshots:
       read-pkg: 9.0.1
       rxjs: 7.8.2
       tsc-prog: 2.3.0(typescript@5.9.2)
-      tsup: 8.5.0(typescript@5.9.2)
+      tsup: 8.5.0(typescript@5.9.2)(yaml@2.8.1)
       typescript: 5.9.2
       write-package: 7.1.0
     transitivePeerDependencies:
@@ -6209,9 +6155,9 @@ snapshots:
       mlly: 1.7.4
       pathe: 2.0.3
 
-  polkadot-api@1.15.2(rxjs@7.8.2):
+  polkadot-api@1.15.2(rxjs@7.8.2)(yaml@2.8.1):
     dependencies:
-      '@polkadot-api/cli': 0.14.4
+      '@polkadot-api/cli': 0.14.4(yaml@2.8.1)
       '@polkadot-api/ink-contracts': 0.3.7
       '@polkadot-api/json-rpc-provider': 0.0.4
       '@polkadot-api/known-chains': 0.9.2
@@ -6244,9 +6190,11 @@ snapshots:
 
   possible-typed-array-names@1.1.0: {}
 
-  postcss-load-config@6.0.1:
+  postcss-load-config@6.0.1(yaml@2.8.1):
     dependencies:
       lilconfig: 3.1.3
+    optionalDependencies:
+      yaml: 2.8.1
 
   prelude-ls@1.2.1: {}
 
@@ -6801,7 +6749,7 @@ snapshots:
 
   tsort@0.0.1: {}
 
-  tsup@8.5.0(typescript@5.9.2):
+  tsup@8.5.0(typescript@5.9.2)(yaml@2.8.1):
     dependencies:
       bundle-require: 5.1.0(esbuild@0.25.8)
       cac: 6.7.14
@@ -6812,7 +6760,7 @@ snapshots:
       fix-dts-default-cjs-exports: 1.0.1
       joycon: 3.1.1
       picocolors: 1.1.1
-      postcss-load-config: 6.0.1
+      postcss-load-config: 6.0.1(yaml@2.8.1)
       resolve-from: 5.0.0
       rollup: 4.46.2
       source-map: 0.8.0-beta.0
@@ -7058,6 +7006,9 @@ snapshots:
   ws@8.18.3: {}
 
   y18n@5.0.8: {}
+
+  yaml@2.8.1:
+    optional: true
 
   yargs-parser@20.2.9: {}
 

--- a/tests/e2e/1-test-in-memory.test.sh
+++ b/tests/e2e/1-test-in-memory.test.sh
@@ -12,10 +12,10 @@ run_test() {
   echo "Running test in fixture-projects/$PROJECT_DIR for ${CONFIG_FILE}; network ${NETWORK_NAME}"
 
   cd "$TMP_TESTS_DIR/$PROJECT_DIR"
-  npm add "$HARDHAT_POLKADOT_NODE_TGZ_PATH"
-  npm add "$HARDHAT_POLKADOT_RESOLC_TGZ_PATH"
-  npm add "$HARDHAT_POLKADOT_TGZ_PATH"
-  npm install
+  pnpm add "$HARDHAT_POLKADOT_NODE_TGZ_PATH"
+  pnpm add "$HARDHAT_POLKADOT_RESOLC_TGZ_PATH"
+  pnpm add "$HARDHAT_POLKADOT_TGZ_PATH"
+  pnpm install
   cp "../$CONFIG_FILE" ./hardhat.config.js
 
   # When

--- a/tests/e2e/2-deploy-in-node.test.sh
+++ b/tests/e2e/2-deploy-in-node.test.sh
@@ -6,10 +6,10 @@ set -e # Fail if any command fails
 # Given
 cp ./basic-test-and-deploy.config.js ./lock/hardhat.config.js
 cd ./lock # relative to tmp folder
-npm add "$HARDHAT_POLKADOT_NODE_TGZ_PATH"
-npm add "$HARDHAT_POLKADOT_RESOLC_TGZ_PATH"
-npm add "$HARDHAT_POLKADOT_TGZ_PATH"
-npm install # install modules specified in the package.json
+pnpm add "$HARDHAT_POLKADOT_NODE_TGZ_PATH"
+pnpm add "$HARDHAT_POLKADOT_RESOLC_TGZ_PATH"
+pnpm add "$HARDHAT_POLKADOT_TGZ_PATH"
+pnpm install # install modules specified in the package.json
 lsof -ti tcp:8000 | xargs -r kill -9
 npx hardhat node > hardhat-node.log 2>&1 & # Start the Hardhat node in the background
 HARDHAT_NODE_PID=$!

--- a/tests/unit/compile-basic.test.sh
+++ b/tests/unit/compile-basic.test.sh
@@ -6,6 +6,7 @@ set -e # Fail if any command fails
 # Given
 cp ./basic-compile.config.js ./foo/hardhat.config.js # relative to tmp folder
 cd ./foo # relative to tmp folder
+pnpm add hardhat@2.26.0
 pnpm add "$HARDHAT_POLKADOT_NODE_TGZ_PATH"
 pnpm add "$HARDHAT_POLKADOT_RESOLC_TGZ_PATH"
 pnpm add "$HARDHAT_POLKADOT_TGZ_PATH"

--- a/tests/unit/compile-basic.test.sh
+++ b/tests/unit/compile-basic.test.sh
@@ -6,10 +6,10 @@ set -e # Fail if any command fails
 # Given
 cp ./basic-compile.config.js ./foo/hardhat.config.js # relative to tmp folder
 cd ./foo # relative to tmp folder
-npm add "$HARDHAT_POLKADOT_NODE_TGZ_PATH"
-npm add "$HARDHAT_POLKADOT_RESOLC_TGZ_PATH"
-npm add "$HARDHAT_POLKADOT_TGZ_PATH"
-npm install # install modules specified in the package.json
+pnpm add "$HARDHAT_POLKADOT_NODE_TGZ_PATH"
+pnpm add "$HARDHAT_POLKADOT_RESOLC_TGZ_PATH"
+pnpm add "$HARDHAT_POLKADOT_TGZ_PATH"
+pnpm install # install modules specified in the package.json
 
 # When
 run_test_and_handle_failure "npx hardhat compile --show-stack-traces" 0

--- a/tests/unit/compile-multiple.test.sh
+++ b/tests/unit/compile-multiple.test.sh
@@ -6,6 +6,7 @@ set -e # Fail if any command fails
 # Given
 cp ./multiple-compile.config.js ./foo/hardhat.config.js # relative to tmp folder
 cd ./foo # relative to tmp folder
+pnpm add hardhat@2.26.0
 pnpm add "$HARDHAT_POLKADOT_NODE_TGZ_PATH"
 pnpm add "$HARDHAT_POLKADOT_RESOLC_TGZ_PATH"
 pnpm add "$HARDHAT_POLKADOT_TGZ_PATH"

--- a/tests/unit/compile-multiple.test.sh
+++ b/tests/unit/compile-multiple.test.sh
@@ -6,10 +6,10 @@ set -e # Fail if any command fails
 # Given
 cp ./multiple-compile.config.js ./foo/hardhat.config.js # relative to tmp folder
 cd ./foo # relative to tmp folder
-npm add "$HARDHAT_POLKADOT_NODE_TGZ_PATH"
-npm add "$HARDHAT_POLKADOT_RESOLC_TGZ_PATH"
-npm add "$HARDHAT_POLKADOT_TGZ_PATH"
-npm install # install modules specified in the package.json
+pnpm add "$HARDHAT_POLKADOT_NODE_TGZ_PATH"
+pnpm add "$HARDHAT_POLKADOT_RESOLC_TGZ_PATH"
+pnpm add "$HARDHAT_POLKADOT_TGZ_PATH"
+pnpm install # install modules specified in the package.json
 
 # When/Then
 run_test_and_handle_failure "npx hardhat compile --show-stack-traces" 0


### PR DESCRIPTION
### Description
This replaces the `npm ...` commando with `pnpm ...` since it was causing problems when installing `solc` for usage with `npm` as the source.

Closes #280 
Rel: https://github.com/paritytech/contract-issues/issues/144