### PR TITLE
feat: add evm backend support

### DIFF
--- a/packages/hardhat-polkadot-resolc/src/types.ts
+++ b/packages/hardhat-polkadot-resolc/src/types.ts
@@ -4,6 +4,7 @@ import { CompilerPlatform } from "hardhat/internal/solidity/compiler/downloader"
 export interface ResolcConfig {
     version: string
     compilerSource?: "binary" | "npm"
+    target?: "evm" | "pvm"
     settings?: {
         // Set the given path as the root of the source tree instead of the root of the filesystem. Passed to `solc` without changes.
         basePath?: string


### PR DESCRIPTION
### Description
This adds support for the EVM Backend.

It adds a field in the `resolc` config to define whether to target `evm` or `pvm`. Specifying `evm` will result in bytecode compatible with EVM, specifying `pvm` or not specifying a value will result in PVM bytecode.

These three options are functional:

```ts
import { HardhatUserConfig } from "hardhat/config"
import "@nomicfoundation/hardhat-toolbox"
import "@parity/hardhat-polkadot-resolc"
import "@parity/hardhat-polkadot-node"

const config: HardhatUserConfig = {
    solidity: "0.8.28",
    resolc: {
        target: "evm"
    },
    networks: {
        hardhat: {
            polkavm: true,
        },
        localNode: {
            polkavm:true,
            url: "http://127.0.0.1:8545"
        }
    },
}

export default config
```
```ts
import { HardhatUserConfig } from "hardhat/config"
import "@nomicfoundation/hardhat-toolbox"
import "@parity/hardhat-polkadot-resolc"
import "@parity/hardhat-polkadot-node"

const config: HardhatUserConfig = {
    solidity: "0.8.28",
    resolc: {
        target: "pvm"
    },
    networks: {
        hardhat: {
            polkavm: true,
        },
        localNode: {
            polkavm:true,
            url: "http://127.0.0.1:8545"
        }
    },
}

export default config
```
```ts
import { HardhatUserConfig } from "hardhat/config"
import "@nomicfoundation/hardhat-toolbox"
import "@parity/hardhat-polkadot-resolc"
import "@parity/hardhat-polkadot-node"

const config: HardhatUserConfig = {
    solidity: "0.8.28",
    networks: {
        hardhat: {
            polkavm: true,
        },
        localNode: {
            polkavm:true,
            url: "http://127.0.0.1:8545"
        }
    },
}

export default config
```

This change only affects `@parity/hardhat-polkadot-resolc`, since the only difference is that we are ignoring most of the compilation process of the plugin and regressing to hardhat's defaults.

Closes #289 