### PR TITLE
chore: test libclang fix for binaries release (macos)

### DIFF
--- a/.github/workflows/release-dev-node.yml
+++ b/.github/workflows/release-dev-node.yml
@@ -1,7 +1,6 @@
 name: Release Polkadot Development Runtime
 
 on:
-  pull_request:
   # trigger manually from /actions
   workflow_dispatch:
     inputs:
@@ -153,7 +152,6 @@ jobs:
           if-no-files-found: error
 
   publish-release:
-    if: false # remove
     name: Publish GitHub Release
     needs: compile
     runs-on: ubuntu-latest


### PR DESCRIPTION
Fixes failed builds of darwin platform with latest polkadot-sdk