### PR TITLE
Bringing back 0x-prefix for EVM bytecode

### DIFF
--- a/packages/hardhat-polkadot-resolc/src/index.ts
+++ b/packages/hardhat-polkadot-resolc/src/index.ts
@@ -35,7 +35,7 @@ import { assertHardhatInvariant } from "hardhat/internal/core/errors"
 import chalk from "chalk"
 import fs from "fs"
 
-import { getArtifactFromContractOutput, pluralize, updateDefaultCompilerConfig } from "./utils"
+import { pluralize, updateDefaultCompilerConfig } from "./utils"
 import { compile } from "./compile"
 import {
     defaultNpmResolcConfig,
@@ -163,24 +163,23 @@ subtask(
 subtask(
     TASK_COMPILE_SOLIDITY_GET_ARTIFACT_FROM_COMPILATION_OUTPUT,
     async (
-        {
-            sourceName,
-            contractName,
-            contractOutput,
-        }: {
+        args: {
             sourceName: string
             contractName: string
             contractOutput: CompilerOutputContract
         },
         hre,
+        runSuper,
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
     ): Promise<any> => {
         if (
             !hre.network.polkadot ||
             (typeof hre.network.polkadot !== "boolean" && hre.network.polkadot?.target == "evm")
         ) {
-            return getArtifactFromContractOutput(sourceName, contractName, contractOutput)
+            return runSuper(args)
         }
+
+        const { sourceName, contractName, contractOutput } = args
         const bytecode: string =
             contractOutput.evm?.bytecode?.object ||
             contractOutput.evm?.deployedBytecode?.object ||

--- a/packages/hardhat-polkadot-resolc/src/utils.ts
+++ b/packages/hardhat-polkadot-resolc/src/utils.ts
@@ -1,36 +1,8 @@
-import type { Artifact, CompilerInput } from "hardhat/types"
-import { ARTIFACT_FORMAT_VERSION } from "hardhat/internal/constants"
+import type { CompilerInput } from "hardhat/types"
 import { createHash } from "crypto"
 import { updateSolc } from "./compile/npm"
 import type { ResolcConfig, SolcConfigData } from "./types"
 import { ResolcPluginError } from "./errors"
-
-export function getArtifactFromContractOutput(
-    sourceName: string,
-    contractName: string,
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    contractOutput: any,
-): Artifact {
-    const evmBytecode = contractOutput.evm?.bytecode
-    const bytecode: string = evmBytecode?.object ?? ""
-
-    const evmDeployedBytecode = contractOutput.evm?.deployedBytecode
-    const deployedBytecode: string = evmDeployedBytecode?.object ?? ""
-
-    const linkReferences = evmBytecode?.linkReferences ?? {}
-    const deployedLinkReferences = evmDeployedBytecode?.linkReferences ?? {}
-
-    return {
-        _format: ARTIFACT_FORMAT_VERSION,
-        contractName,
-        sourceName,
-        abi: contractOutput.abi,
-        bytecode,
-        deployedBytecode,
-        linkReferences,
-        deployedLinkReferences,
-    }
-}
 
 export function getVersionComponents(version: string): number[] {
     const versionComponents = version.split(".")


### PR DESCRIPTION
Original implementation is identical to the one I'm removing, except for
adding `0x` before the bytecode.
Missing `0x` at the beginning worked okay for some contracts, but it
leads to issues with `linkReferences` having wrong offset.

After talking to @bee344, decided to remove our implementation and just
use `runSuper()` instead
