### PR TITLE
fix(hardhat-polkadot-node): remove cli arguments

### DIFF
--- a/packages/hardhat-polkadot-node/src/types.ts
+++ b/packages/hardhat-polkadot-node/src/types.ts
@@ -2,17 +2,6 @@ import { HardhatNetworkForkingUserConfig } from "hardhat/types"
 import { HardhatNetworkUserConfig } from "hardhat/types/config"
 import { ChopsticksService, EthRpcService, SubstrateNodeService } from "./services"
 
-export interface CliCommands {
-    nodeBinaryPath?: string
-    rpcPort?: number
-    adapterBinaryPath?: string
-    adapterPort?: number
-    dev?: boolean
-    buildBlockMode?: "Instant" | "Manual" | "Batch"
-    fork?: string
-    forkBlockNumber?: string
-}
-
 export interface CommandArguments {
     forking?: HardhatNetworkForkingUserConfig
     forkBlockNumber?: string | number


### PR DESCRIPTION
### Description

This removes the type `cliArguments`. For the time being they are not being used and just clutter the code.