### PR TITLE
fix(hardhat-polkadot-resolc): removed 'latest' as valid version

### DIFF
--- a/packages/hardhat-polkadot-resolc/src/constants.ts
+++ b/packages/hardhat-polkadot-resolc/src/constants.ts
@@ -13,13 +13,13 @@ export const COMPILER_REPOSITORY_URL = "https://github.com/paritytech/revive/rel
 export const COMPILER_REPOSITORY_API_URL = "https://api.github.com/repos/paritytech/revive/releases"
 
 export const defaultNpmResolcConfig: ResolcConfig = {
-    version: "latest",
+    version: "0.1.0",
     compilerSource: "npm",
     settings: {},
 }
 
 export const defaultBinaryResolcConfig: ResolcConfig = {
-    version: "latest",
+    version: "0.1.0",
     compilerSource: "binary",
     settings: {
         optimizer: {

--- a/packages/hardhat-polkadot-resolc/src/downloader.ts
+++ b/packages/hardhat-polkadot-resolc/src/downloader.ts
@@ -201,9 +201,8 @@ export class ResolcCompilerDownloader implements IResolcCompilerDownloader {
         }
 
         const list = await this._readCompilerList(listPath)
-        if (version === "latest") {
-            const latestVersion = list.latestRelease.slice(1)
-            return list.builds.find((b) => b.version === latestVersion)
+        if (Number.isNaN(parseInt(version))) {
+            throw new ResolcPluginError(`${version} is not a valid version.`)
         }
 
         return list.builds.find((b) => b.version === version)

--- a/packages/hardhat-polkadot-resolc/src/index.ts
+++ b/packages/hardhat-polkadot-resolc/src/index.ts
@@ -341,11 +341,7 @@ subtask(TASK_COMPILE_SOLIDITY_LOG_DOWNLOAD_RESOLC_COMPILER_START).setAction(
             return
         }
 
-        if (resolcVersion === "latest") {
-            console.log(`Downloading ${resolcVersion} version of the resolc compiler`)
-        } else {
-            console.log(`Downloading resolc compiler ${resolcVersion}`)
-        }
+        console.log(`Downloading resolc compiler ${resolcVersion}`)
     },
 )
 


### PR DESCRIPTION
### Description

"latest" was giving trouble, specially on MacOS, and since it is not standard usage, the simplest fix is to just remove it.

Closes #306 