### PR TITLE
fix(hardhat-polkadot-resolc): remove suffix

### DIFF
--- a/examples/all-polkavm-networks/.gitignore
+++ b/examples/all-polkavm-networks/.gitignore
@@ -4,8 +4,6 @@ node_modules
 .env
 
 # Hardhat files
-/cache-pvm
-/artifacts-pvm
 /cache
 /artifacts
 

--- a/examples/forking/.gitignore
+++ b/examples/forking/.gitignore
@@ -4,8 +4,6 @@ node_modules
 .env
 
 # Hardhat files
-/cache-pvm
-/artifacts-pvm
 /cache
 /artifacts
 

--- a/examples/using-docker/.gitignore
+++ b/examples/using-docker/.gitignore
@@ -6,8 +6,6 @@ node_modules
 # Hardhat files
 /cache
 /artifacts
-/cache-pvm
-/artifacts-pvm
 
 # TypeChain files
 /typechain

--- a/examples/using-xcm/.gitignore
+++ b/examples/using-xcm/.gitignore
@@ -4,8 +4,6 @@ node_modules
 .env
 
 # Hardhat files
-/cache-pvm
-/artifacts-pvm
 /cache
 /artifacts
 

--- a/examples/with-evm-networks/.gitignore
+++ b/examples/with-evm-networks/.gitignore
@@ -6,8 +6,6 @@ node_modules
 # Hardhat files
 /cache
 /artifacts
-/cache-pvm
-/artifacts-pvm
 
 # TypeChain files
 /typechain

--- a/packages/hardhat-polkadot-resolc/src/index.ts
+++ b/packages/hardhat-polkadot-resolc/src/index.ts
@@ -5,7 +5,6 @@ import {
     TASK_COMPILE_SOLIDITY_LOG_COMPILATION_RESULT,
     TASK_COMPILE_SOLIDITY_LOG_RUN_COMPILER_START,
     TASK_COMPILE_SOLIDITY_GET_SOURCE_NAMES,
-    TASK_COMPILE_REMOVE_OBSOLETE_ARTIFACTS,
     TASK_COMPILE_SOLIDITY_COMPILE_SOLC,
     TASK_COMPILE_SOLIDITY_LOG_RUN_COMPILER_END,
     TASK_COMPILE_SOLIDITY_EMIT_ARTIFACTS,
@@ -33,7 +32,6 @@ import type {
 } from "hardhat/types"
 import { assertHardhatInvariant } from "hardhat/internal/core/errors"
 import chalk from "chalk"
-import fs from "fs"
 
 import { pluralize, updateDefaultCompilerConfig } from "./utils"
 import { compile } from "./compile"
@@ -91,15 +89,9 @@ extendEnvironment((hre) => {
     hre.network.polkadot = hre.network.config.polkadot
     if (typeof hre.network.polkadot !== "boolean" && hre.network.polkadot?.target == "evm") return
 
-    let artifactsPath = hre.config.paths.artifacts
-    if (!artifactsPath.endsWith("-pvm")) {
-        artifactsPath = `${artifactsPath}-pvm`
-    }
+    const artifactsPath = hre.config.paths.artifacts
 
-    let cachePath = hre.config.paths.cache
-    if (!cachePath.endsWith("-pvm")) {
-        cachePath = `${cachePath}-pvm`
-    }
+    const cachePath = hre.config.paths.cache
 
     hre.config.paths.artifacts = artifactsPath
     hre.config.paths.cache = cachePath
@@ -537,21 +529,4 @@ subtask(TASK_COMPILE_SOLIDITY_GET_COMPILER_INPUT, async (taskArgs, hre, runSuper
     const compilerInput: ReviveCompilerInput = await runSuper(taskArgs)
 
     return compilerInput
-})
-
-subtask(TASK_COMPILE_REMOVE_OBSOLETE_ARTIFACTS, async (taskArgs, hre, runSuper) => {
-    if (
-        !hre.network.polkadot ||
-        (typeof hre.network.polkadot !== "boolean" && hre.network.polkadot?.target == "evm")
-    ) {
-        return await runSuper(taskArgs)
-    }
-
-    const artifactsDir = hre.config.paths.artifacts
-
-    if (artifactsDir.slice(-4) !== "-pvm") fs.rmSync(artifactsDir, { recursive: true })
-
-    const cacheDir = hre.config.paths.cache
-
-    if (cacheDir.slice(-4) !== "-pvm") fs.rmSync(cacheDir, { recursive: true })
 })

--- a/packages/hardhat-polkadot/recommended-gitignore.txt
+++ b/packages/hardhat-polkadot/recommended-gitignore.txt
@@ -2,8 +2,6 @@ node_modules
 .env
 
 # Hardhat files
-/cache-pvm
-/artifacts-pvm
 /cache
 /artifacts
 

--- a/tests/e2e/1-test-in-memory.test.sh
+++ b/tests/e2e/1-test-in-memory.test.sh
@@ -20,8 +20,8 @@ run_test() {
   RUN_TESTS_OUTPUT="$(FORCE_COLOR=1 npx hardhat test --show-stack-traces | tee /dev/stderr)"
 
   # Then
-  assert_directory_not_empty "artifacts-pvm"
-  assert_directory_not_empty "cache-pvm"
+  assert_directory_not_empty "artifacts"
+  assert_directory_not_empty "cache"
   check_log_value "$RUN_TESTS_OUTPUT" "$EXPECTED_PASSING passing"
   echo "✅ Tests in $NETWORK_NAME network passed in fixture-projects/$PROJECT_DIR"
 }

--- a/tests/e2e/2-deploy-in-node.test.sh
+++ b/tests/e2e/2-deploy-in-node.test.sh
@@ -25,8 +25,8 @@ run_test() {
   )"
 
   # Then
-  assert_directory_not_empty "artifacts-pvm"
-  assert_directory_not_empty "cache-pvm"
+  assert_directory_not_empty "artifacts"
+  assert_directory_not_empty "cache"
   check_log_value "$DEPLOY_LOCAL_NODE_OUTPUT" "${CONTRACT_NAME}Module#${CONTRACT_NAME} - 0x"
   echo "Deploys on $NETWORK_NAME network successfully in fixture-projects/${PROJECT_DIR} ✅"
 

--- a/tests/unit/compile-basic.test.sh
+++ b/tests/unit/compile-basic.test.sh
@@ -13,10 +13,10 @@ npm install # install modules specified in the package.json
 run_test_and_handle_failure "npx hardhat compile --show-stack-traces" 0
 
 # Then
-assert_directory_exists "artifacts-pvm"
-assert_directory_exists "cache-pvm"
-assert_directory_not_empty "artifacts-pvm"
-assert_directory_not_empty "cache-pvm"
+assert_directory_exists "artifacts"
+assert_directory_exists "cache"
+assert_directory_not_empty "artifacts"
+assert_directory_not_empty "cache"
 
 echo "Solidity compiles successfully in fixture-pojects/foo" \
     "creating the appropriate artifacts ✅"


### PR DESCRIPTION
### Description

Removes the `-pvm` suffix for `cache` and `artifacts`.

Closes #27 