### PR TITLE
chore: add release CI for anvil dev node

### DIFF
--- a/.github/workflows/release-anvil-polkadot-nodes.yml
+++ b/.github/workflows/release-anvil-polkadot-nodes.yml
@@ -1,0 +1,207 @@
+name: Release Anvil Development Node
+
+on:
+  # trigger manually from /actions
+  workflow_dispatch:
+    inputs:
+      foundry-polkadot-branch:
+        description: Branch to use for foundry-polkadot
+        required: true
+        default: "master"
+      mark-as-latest:
+        type: boolean
+        required: false
+        default: false
+        description: Mark as latest
+
+permissions:
+  contents: write
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+env:
+  FOUNDRY_POLKADOT_REPO: 'https://github.com/paritytech/foundry-polkadot'
+  FOUNDRY_POLKADOT_BRANCH: ${{ inputs.foundry-polkadot-branch || 'master' }}
+
+jobs:
+  compile:
+    name: Build ${{ matrix.target }}
+    strategy:
+      fail-fast: false
+      matrix:
+        target: [x86_64-unknown-linux-gnu, aarch64-apple-darwin]
+        include:
+          - target: x86_64-unknown-linux-gnu
+            os_tag: linux
+            arch_tag: x64
+            runner: parity-default
+            exe_ext: ''
+          - target: aarch64-apple-darwin
+            os_tag: darwin
+            arch_tag: arm64
+            runner: parity-macos
+            exe_ext: ''
+
+    runs-on: ${{ matrix.runner }}
+    steps:
+
+      # These are minimal dependencies for building the nodes.
+      # Some references:
+      # 1. https://github.com/paritytech/polkadot-sdk/blob/2db5e16bf2b497e8ef877d3d7e79b3fcdcab5f82/scripts/getting-started.sh#L59
+      # 2. https://github.com/paritytech/dockerfiles/blob/main/ci-unified/Dockerfile
+      - name: Install shared dependencies (Linux)
+        if: matrix.os_tag == 'linux'
+        run: |
+          sudo apt update
+          sudo apt install -y openssl pkg-config g++ git clang cmake curl libssl-dev llvm libudev-dev libclang-dev make protobuf-compiler jq
+
+      - name: Install brew
+        if: matrix.os_tag == 'darwin'
+        uses: Homebrew/actions/setup-homebrew@1ccc07ccd54b6048295516a3eb89b192c35057dc # master from 12.09.2024
+
+      - name: Install shared dependencies (macOS)
+        if: matrix.os_tag == 'darwin'
+        run: |
+          xcode-select --install || true
+          
+          # Set libclang environment variables
+          XCODE_PATH=$(xcode-select --print-path)
+          echo "LIBCLANG_PATH=${XCODE_PATH}/Toolchains/XcodeDefault.xctoolchain/usr/lib" >> $GITHUB_ENV
+          echo "DYLD_LIBRARY_PATH=${XCODE_PATH}/Toolchains/XcodeDefault.xctoolchain/usr/lib:$DYLD_LIBRARY_PATH" >> $GITHUB_ENV
+
+          brew uninstall cmake
+          brew install openssl pkg-config git curl llvm protobuf jq cmake
+
+      - name: Checkout (repo context)
+        uses: actions/checkout@v4
+
+      - name: Clone foundry-polkadot
+        shell: bash
+        run: |
+          git clone --depth 1 --branch "$FOUNDRY_POLKADOT_BRANCH" "$FOUNDRY_POLKADOT_REPO" foundry-polkadot
+
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@v1
+        id: toolchain
+        with:
+          toolchain: '1.88.0'
+          targets: wasm32-unknown-unknown, ${{ matrix.target }}
+          components: rustfmt, clippy, rust-src
+
+      - name: Check environment
+        run: |
+          rustc --version
+          cargo --version
+          df -h
+
+      - name: Cache cargo
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            foundry-polkadot/target
+          key: ${{ runner.os }}-cargo-${{ matrix.target }}-${{ steps.toolchain.outputs.cachekey }}
+
+      - name: Build anvil-polkadot nodes
+        working-directory: foundry-polkadot
+        shell: bash
+        run: |
+          set -euxo pipefail
+          cargo build --release --target ${{ matrix.target }} -p anvil-polkadot
+
+      - name: Stage artifact with OS/arch suffix
+        shell: bash
+        run: |
+          set -euo pipefail
+          mkdir -p out
+
+          cp "foundry-polkadot/target/${{ matrix.target }}/release/anvil-polkadot${{ matrix.exe_ext }}" "out/anvil-polkadot-${{ matrix.os_tag }}-${{ matrix.arch_tag }}${{ matrix.exe_ext }}"
+
+      - name: Upload artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: anvil-polkadot-nodes-${{ matrix.os_tag }}-${{ matrix.arch_tag }}
+          path: out/*
+          if-no-files-found: error
+
+  publish-release:
+    name: Publish GitHub Release
+    needs: compile
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Download artifacts
+        uses: actions/download-artifact@v4
+        with:
+          path: dist
+          merge-multiple: true
+
+      - name: List downloaded files
+        run: |
+          ls -la dist
+
+      - name: Save latest commit hash to env
+        run: |
+          echo "LATEST_COMMIT_HASH=$(git ls-remote ${{ env.FOUNDRY_POLKADOT_REPO }} refs/heads/${{ env.FOUNDRY_POLKADOT_BRANCH }} | awk '{ print $1 }')" >> "$GITHUB_ENV"
+
+      - name: Generate checksums and release body
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          DATE=$(date +'%Y-%m-%dT%H:%M:%S%z')
+
+          # switch to dist folder, so that we can generate checksums for all downloaded artifacts
+          pushd dist >/dev/null
+          shasum -a 256 * > checksums.txt
+          popd >/dev/null # switch back to root folder
+
+          # Build release notes with real date and checksums
+          {
+            echo "Build date: ${DATE}"
+            echo "Based on [${{ env.FOUNDRY_POLKADOT_BRANCH }}](https://github.com/paritytech/foundry-polkadot/tree/${{ env.FOUNDRY_POLKADOT_BRANCH }})#[${{ env.LATEST_COMMIT_HASH }}](${{ env.FOUNDRY_POLKADOT_REPO }}/commit/${{ env.LATEST_COMMIT_HASH }})"
+            echo
+            echo "⚠️ Disclaimer: This is a temporary release for testing purposes, it may not be stable and not meant to be used in production."
+            echo
+            echo "This release includes anvil-polkadot binaries for the following platforms:"
+            echo
+            echo "  - Linux x86_64"
+            echo "  - macOS arm64"
+            echo
+            echo "Checksums:"
+            echo '```'
+            sed 's/^/  /' dist/checksums.txt
+            echo '```'
+          } > RELEASE_BODY.md
+
+          echo "Generated release notes:"
+          echo
+          cat RELEASE_BODY.md
+
+      - name: Create GitHub Release
+        uses: softprops/action-gh-release@v2
+        with:
+          tag_name: anvil-polkadot-nodes-${{ github.run_id }}
+          name: Anvil-polkadot nodes build ${{ github.run_id }}
+          draft: false
+          prerelease: true # to prevent marking as latest, since it should be a main npm package
+          generate_release_notes: false
+          body_path: RELEASE_BODY.md
+          files: |
+            dist/*
+
+      - name: Create/Update Latest Tag (anvil-polkadot-nodes-latest)
+        if: inputs.mark-as-latest
+        uses: softprops/action-gh-release@v2
+        with:
+          tag_name: anvil-polkadot-nodes-latest
+          name: Anvil-polkadot nodes latest
+          draft: false
+          prerelease: true # to prevent marking as latest, since it should be a main npm package
+          generate_release_notes: false
+          body_path: RELEASE_BODY.md
+          files: |
+            dist/*


### PR DESCRIPTION
### Description

The goal of this is to make the anvil node available for usage without the user needing to compile it, as well as enable testing via CI in a simple way.

Clone of https://github.com/paritytech/hardhat-polkadot/blob/main/.github/workflows/release-dev-node.yml