### PR TITLE
fix(hardhat-polkadot-node): increase dev accounts to 20 in anvil

### DIFF
--- a/packages/hardhat-polkadot-node/src/utils.ts
+++ b/packages/hardhat-polkadot-node/src/utils.ts
@@ -37,6 +37,7 @@ export function constructCommandArgs(args?: CommandArguments): SplitCommands {
     const adapterCommands: string[] = []
 
     if (args?.nodeCommands?.useAnvil && !args.forking) {
+        nodeCommands.push("", "--accounts", "20")
         return {
             nodeCommands,
             adapterCommands,


### PR DESCRIPTION
### Description

This spins up the anvil-polkadot node with 20 accounts instead of the default 10, in order to comply with the hardhat standard.