### PR TITLE
fix(@parity/hardhat-polkadot-node): increase polling rate

### DIFF
--- a/packages/hardhat-polkadot-node/src/index.ts
+++ b/packages/hardhat-polkadot-node/src/index.ts
@@ -37,6 +37,7 @@ import { handleFactoryDependencies } from "./core/factory-support"
 import { runScriptWithHardhat } from "./core/script-runner"
 import { RpcServer } from "./types"
 import "./type-extensions"
+import { intervalPollingPatch } from "./polling-patch"
 
 task(TASK_RUN).setAction(async (args, hre, runSuper) => {
     if (!hre.network.polkadot || hre.network.name !== HARDHAT_NETWORK_NAME) {
@@ -268,3 +269,5 @@ scope("ignition").task("deploy", async (_taskArgs, { config }, runSuper) => {
 })
 
 interceptAndWrapTasksWithNode()
+
+intervalPollingPatch()

--- a/packages/hardhat-polkadot-node/src/polling-patch.ts
+++ b/packages/hardhat-polkadot-node/src/polling-patch.ts
@@ -1,0 +1,29 @@
+import Module from "module"
+
+export function intervalPollingPatch(customInterval = 10) {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const originalRequire = Module.prototype.require as any
+
+    Module.prototype.require = function (id: string) {
+        // eslint-disable-next-line prefer-rest-params
+        const module = originalRequire.apply(this, arguments)
+
+        if (id === "ethers" || id.includes("@nomiclabs/hardhat-ethers")) {
+            if (module.providers?.BaseProvider) {
+                const proto = module.providers.BaseProvider.prototype
+                if (!proto._pollingPatched) {
+                    const orig = proto._ready
+                    proto._ready = async function () {
+                        this._pollingInterval = customInterval
+                        const result = await orig.call(this)
+                        this._pollingInterval = customInterval
+                        return result
+                    }
+                    proto._pollingPatched = true
+                }
+            }
+        }
+
+        return module
+    }
+}


### PR DESCRIPTION
### Description

This decreases the polling interval usde by the ethers provider, which in turn speeds up the tests. This is necessary until we enable subscriptions on the test node, since until then ethers switch to a "polling" mode, where it polls the chain every 4 secs. Here we are changing it to 10 ms.

To give an example of the improvement, this is before the update:

```sh
  347 passing (55m)
  12 failing
```

And this is after:

```sh
347 passing (1m)
12 failing
```