### PR TITLE
fix(hardhat-polkadot-resolc): custom compiler version not being used

### DIFF
--- a/packages/hardhat-polkadot-resolc/src/constants.ts
+++ b/packages/hardhat-polkadot-resolc/src/constants.ts
@@ -13,13 +13,13 @@ export const COMPILER_REPOSITORY_URL = "https://github.com/paritytech/revive/rel
 export const COMPILER_REPOSITORY_API_URL = "https://api.github.com/repos/paritytech/revive/releases"
 
 export const defaultNpmResolcConfig: ResolcConfig = {
-    version: "0.5.0",
+    version: "0.6.0",
     compilerSource: "npm",
     settings: {},
 }
 
 export const defaultBinaryResolcConfig: ResolcConfig = {
-    version: "0.5.0",
+    version: "0.6.0",
     compilerSource: "binary",
     settings: {
         optimizer: {

--- a/packages/hardhat-polkadot-resolc/src/index.ts
+++ b/packages/hardhat-polkadot-resolc/src/index.ts
@@ -103,8 +103,8 @@ extendEnvironment((hre) => {
 
     hre.config.paths.artifacts = artifactsPath
     hre.config.paths.cache = cachePath
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        ; (hre as any).artifacts = new Artifacts(artifactsPath)
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    ;(hre as any).artifacts = new Artifacts(artifactsPath)
 
     if (
         (hre.config.solidity.compilers.length > 1 && hre.config.resolc.compilerSource === "npm") ||
@@ -356,7 +356,6 @@ subtask(TASK_COMPILE_SOLIDITY_GET_RESOLC_BUILD).setAction(
         },
         { run, config },
     ): Promise<ResolcBuild> => {
-
         const customResolcPath = config.resolc?.settings?.resolcPath
         if (customResolcPath) {
             console.log(`Using custom resolc binary: ${customResolcPath}`)


### PR DESCRIPTION
### Description
Updates the version handling. Before, when defining a specific version in the `resolc` settings, in the build-info file generated during the compilation process, the version that would show up as `resolc`'s was the version defined in the default configuration. This has now been fixed.
On the other hand, the compilation process had an bug where it would download a binary even if there was a custom binary path defined in the configuration.