### PR TITLE
feat: hardhat 3 compat part 2

### DIFF
--- a/packages/hardhat-polkadot-node/src/core/factory-support.ts
+++ b/packages/hardhat-polkadot-node/src/core/factory-support.ts
@@ -3,9 +3,9 @@ import fs from "fs"
 import { glob } from "fast-glob"
 import chalk from "chalk"
 import type {
-    HardhatNetworkConfig,
+    EdrNetworkConfig,
     HttpNetworkAccountsConfig,
-} from "hardhat/types"
+} from "hardhat/types/config"
 import { createClient, Binary } from "polkadot-api"
 import { getWsProvider } from "polkadot-api/ws-provider/web"
 import path from "path"
@@ -29,8 +29,8 @@ type Contracts = Record<
  */
 export async function handleFactoryDependencies(
     pathToArtifacts: string,
-    ethRpcUrl: HardhatNetworkConfig["url"],
-    polkadotRpcUrl: HardhatNetworkConfig["polkadotUrl"],
+    ethRpcUrl: EdrNetworkConfig["url"],
+    polkadotRpcUrl: EdrNetworkConfig["polkadotUrl"],
     accounts: string[] | HttpNetworkAccountsConfig,
     useAnvil?: boolean,
 ) {

--- a/packages/hardhat-polkadot-node/src/rpc-server.ts
+++ b/packages/hardhat-polkadot-node/src/rpc-server.ts
@@ -1,4 +1,4 @@
-import { HardhatNetworkUserConfig } from "hardhat/types/config"
+import type { EdrNetworkUserConfig } from "hardhat/types/config"
 import Docker from "dockerode"
 
 import { PolkadotNodePluginError } from "./errors.js"
@@ -10,7 +10,7 @@ import { getDockerSocketPath } from "./utils.js"
 
 export function createRpcServer(opts: {
     useAnvil: boolean
-    docker?: HardhatNetworkUserConfig["docker"]
+    docker?: EdrNetworkUserConfig["docker"]
     nodePath?: string
     adapterPath?: string
     isForking?: boolean

--- a/packages/hardhat-polkadot-node/src/type-extensions.ts
+++ b/packages/hardhat-polkadot-node/src/type-extensions.ts
@@ -2,7 +2,7 @@ import "hardhat/types/config"
 import type { TargetVM } from "./types.js"
 
 declare module "hardhat/types/config" {
-    interface HardhatNetworkUserConfig {
+    interface EdrNetworkUserConfig {
         // Replace EVM-compatible node with polkadot-compatible node
         polkadot?: boolean | TargetVM
         // Configuration for polkadot-compatible node
@@ -46,7 +46,7 @@ declare module "hardhat/types/config" {
         polkadot?: boolean | TargetVM
     }
 
-    interface HardhatNetworkConfig {
+    interface EdrNetworkConfig {
         polkadot?: boolean | TargetVM
         url?: string
         polkadotUrl?: string
@@ -56,11 +56,5 @@ declare module "hardhat/types/config" {
         polkadot?: boolean | TargetVM
         ethNetwork?: string
         polkadotUrl?: string
-    }
-}
-
-declare module "hardhat/types/runtime" {
-    interface Network {
-        polkadot?: boolean | TargetVM
     }
 }

--- a/packages/hardhat-polkadot-node/src/types.ts
+++ b/packages/hardhat-polkadot-node/src/types.ts
@@ -1,4 +1,4 @@
-import { HardhatNetworkUserConfig } from "hardhat/types/config"
+import type { EdrNetworkUserConfig } from "hardhat/types/config"
 import { ChopsticksService, EthRpcService, SubstrateNodeService } from "./services/index.js"
 
 /**
@@ -14,9 +14,9 @@ export interface ForkingUserConfig {
 export interface CommandArguments {
     forking?: ForkingUserConfig
     forkBlockNumber?: string | number
-    nodeCommands?: HardhatNetworkUserConfig["nodeConfig"]
-    adapterCommands?: HardhatNetworkUserConfig["adapterConfig"]
-    docker?: HardhatNetworkUserConfig["docker"]
+    nodeCommands?: EdrNetworkUserConfig["nodeConfig"]
+    adapterCommands?: EdrNetworkUserConfig["adapterConfig"]
+    docker?: EdrNetworkUserConfig["docker"]
 }
 
 export interface RpcServer {

--- a/packages/hardhat-polkadot-node/src/utils.ts
+++ b/packages/hardhat-polkadot-node/src/utils.ts
@@ -1,11 +1,10 @@
 import axios from "axios"
 import net from "net"
-import type { HardhatConfig } from "hardhat/types"
+import type { HardhatConfig, EdrNetworkConfig, EdrNetworkUserConfig } from "hardhat/types/config"
 import { LRUCache } from "lru-cache"
 import fs from "fs"
 import os from "os"
 import path from "path"
-import type { HardhatNetworkConfig, HardhatNetworkUserConfig } from "hardhat/types/config"
 
 import { createRpcServer } from "./rpc-server.js"
 import type { CommandArguments, SplitCommands } from "./types.js"
@@ -289,8 +288,8 @@ export async function getLatestImageName(containerName: string): Promise<string 
 }
 
 export function getDockerSocketPath(
-    docker?: HardhatNetworkUserConfig["docker"],
-): Extract<HardhatNetworkUserConfig["docker"], string> {
+    docker?: EdrNetworkUserConfig["docker"],
+): Extract<EdrNetworkUserConfig["docker"], string> {
     const customDockerSocketPath = typeof docker === "string" ? docker : undefined
     const dockerSocketPath =
         customDockerSocketPath ||
@@ -336,8 +335,8 @@ export async function waitForServiceToBeReady(
 }
 
 export function getPolkadotRpcUrl(
-    ethRpcUrl: HardhatNetworkConfig["url"],
-    polkadotRpcUrl: HardhatNetworkConfig["polkadotUrl"],
+    ethRpcUrl: EdrNetworkConfig["url"],
+    polkadotRpcUrl: EdrNetworkConfig["polkadotUrl"],
     useAnvil: boolean = false,
 ): string {
     // Case 1: we are using anvil as the node

--- a/packages/hardhat-polkadot-resolc/src/compile/binary.ts
+++ b/packages/hardhat-polkadot-resolc/src/compile/binary.ts
@@ -1,5 +1,5 @@
 import { spawn } from "child_process"
-import type { CompilerInput } from "hardhat/types"
+import type { CompilerInput } from "hardhat/types/solidity"
 import type { ResolcConfig } from "../types.js"
 import { extractCommands } from "../utils.js"
 import { ResolcPluginError } from "../errors.js"

--- a/packages/hardhat-polkadot-resolc/src/compile/index.ts
+++ b/packages/hardhat-polkadot-resolc/src/compile/index.ts
@@ -1,4 +1,4 @@
-import type { CompilerInput } from "hardhat/types"
+import type { CompilerInput } from "hardhat/types/solidity"
 import type { ICompiler, ResolcConfig } from "../types.js"
 import { ResolcPluginError } from "../errors.js"
 import { compileWithBinary } from "./binary.js"

--- a/packages/hardhat-polkadot-resolc/src/compile/npm.ts
+++ b/packages/hardhat-polkadot-resolc/src/compile/npm.ts
@@ -3,7 +3,7 @@ import { exec as execCb, execSync } from "child_process"
 import { promisify } from "util"
 import semver from "semver"
 import { compile, resolveInputs, type SolcOutput } from "@parity/resolc"
-import type { CompilerInput } from "hardhat/types"
+import type { CompilerInput } from "hardhat/types/solidity"
 import type { ResolcConfig } from "../types.js"
 import { ResolcPluginError } from "../errors.js"
 

--- a/packages/hardhat-polkadot-resolc/src/type-extensions.ts
+++ b/packages/hardhat-polkadot-resolc/src/type-extensions.ts
@@ -11,7 +11,7 @@ declare module "hardhat/types/config" {
         resolc: ResolcConfig
     }
 
-    interface HardhatNetworkUserConfig {
+    interface EdrNetworkUserConfig {
         polkadot?: boolean | TargetVM
     }
 
@@ -19,15 +19,11 @@ declare module "hardhat/types/config" {
         polkadot?: boolean | TargetVM
     }
 
-    interface HardhatNetworkConfig {
+    interface EdrNetworkConfig {
         polkadot?: boolean | TargetVM
     }
 
     interface HttpNetworkConfig {
-        polkadot?: boolean | TargetVM
-    }
-
-    interface NetworksConfig {
         polkadot?: boolean | TargetVM
     }
 }

--- a/packages/hardhat-polkadot-resolc/src/types.ts
+++ b/packages/hardhat-polkadot-resolc/src/types.ts
@@ -1,4 +1,5 @@
-import type { CompilerInput, SolcConfig } from "hardhat/types"
+import type { SolcConfig } from "hardhat/types/config"
+import type { CompilerInput } from "hardhat/types/solidity"
 
 /**
  * Compiler platform identifiers (local definition replacing hardhat v2's internal enum).

--- a/packages/hardhat-polkadot-resolc/src/utils.ts
+++ b/packages/hardhat-polkadot-resolc/src/utils.ts
@@ -1,4 +1,4 @@
-import type { CompilerInput } from "hardhat/types"
+import type { CompilerInput } from "hardhat/types/solidity"
 import { createHash } from "crypto"
 import { updateSolc } from "./compile/npm.js"
 import type { ResolcConfig, SolcConfigData } from "./types.js"


### PR DESCRIPTION
Type extensions: migrate module augmentation paths to Hardhat v3 interfaces

Module augmentation updates:
- declare module "hardhat/types/config" kept as-is (v3 exports map keys don't include .js)
- declare module "hardhat/types/runtime" removed from `hardhat-polkadot-node` (no runtime module in v3)
- `NetworksConfig` augmentation removed from `hardhat-polkadot-resolc` (doesn't exist in v3)

Renamed v2 network interfaces to v3 equivalents:
- `HardhatNetworkUserConfig` is now `EdrNetworkUserConfig`
- `HardhatNetworkConfig` is now `EdrNetworkConfig`

Updated type imports across both packages:
- `CompilerInput` now from `hardhat/types/solidity`
- `SolcConfig` now from `hardhat/types/config`
- `HardhatConfig`, `EdrNetworkUserConfig`, `EdrNetworkConfig`, `HttpNetworkAccountsConfig` from `hardhat/types/config`