### PR TITLE
feat: hardhat 3 compat part 3

### DIFF
--- a/packages/hardhat-polkadot-resolc/package.json
+++ b/packages/hardhat-polkadot-resolc/package.json
@@ -10,6 +10,7 @@
     "type": "git",
     "url": "https://github.com/paritytech/hardhat-polkadot.git"
   },
+  "type": "module",
   "main": "dist/index.js",
   "publishConfig": {
     "access": "public"

--- a/packages/hardhat-polkadot-resolc/src/hook-handlers/config.ts
+++ b/packages/hardhat-polkadot-resolc/src/hook-handlers/config.ts
@@ -1,0 +1,99 @@
+import type { ConfigHooks, HardhatUserConfigValidationError } from "hardhat/types/hooks"
+import type { HardhatUserConfig } from "hardhat/types/config"
+
+import { defaultNpmResolcConfig, defaultBinaryResolcConfig } from "../constants.js"
+import type { ResolcConfig } from "../types.js"
+
+function hasPolkadotNetwork(config: HardhatUserConfig): boolean {
+    const networks = config.networks ?? {}
+    return Object.values(networks).some(
+        (network) => network && "polkadot" in network && !!network.polkadot,
+    )
+}
+
+function isTargetingEvm(config: HardhatUserConfig): boolean {
+    const networks = config.networks ?? {}
+    return Object.values(networks).some(
+        (network) =>
+            network &&
+            "polkadot" in network &&
+            typeof network.polkadot !== "boolean" &&
+            network.polkadot?.target === "evm",
+    )
+}
+
+function resolveResolcConfig(userConfig: HardhatUserConfig): ResolcConfig {
+    const isNpm = userConfig.resolc?.compilerSource === "npm"
+    const defaultConfig = isNpm ? defaultNpmResolcConfig : defaultBinaryResolcConfig
+    const customConfig = userConfig.resolc ?? {}
+
+    const optimizer = {
+        ...defaultConfig.settings?.optimizer,
+        ...customConfig.settings?.optimizer,
+    }
+
+    return {
+        ...defaultConfig,
+        ...customConfig,
+        settings: {
+            ...customConfig.settings,
+            optimizer,
+        },
+    }
+}
+
+const configHookHandler: () => Promise<Partial<ConfigHooks>> = async () => ({
+    extendUserConfig: async (config, next) => {
+        if (!hasPolkadotNetwork(config) || isTargetingEvm(config)) {
+            return next(config)
+        }
+
+        const resolc = resolveResolcConfig(config)
+
+        return next({
+            ...config,
+            resolc,
+        })
+    },
+
+    validateUserConfig: async (config) => {
+        const errors: HardhatUserConfigValidationError[] = []
+
+        if (config.resolc === undefined) return errors
+
+        if (
+            config.resolc.compilerSource !== undefined &&
+            config.resolc.compilerSource !== "binary" &&
+            config.resolc.compilerSource !== "npm"
+        ) {
+            errors.push({
+                path: ["resolc", "compilerSource"],
+                message: `Invalid compiler source: "${config.resolc.compilerSource}". Must be "binary" or "npm".`,
+            })
+        }
+
+        if (config.resolc.version !== undefined && typeof config.resolc.version !== "string") {
+            errors.push({
+                path: ["resolc", "version"],
+                message: "Expected a string for resolc version.",
+            })
+        }
+
+        return errors
+    },
+
+    resolveUserConfig: async (userConfig, resolveConfigurationVariable, next) => {
+        const resolvedConfig = await next(userConfig, resolveConfigurationVariable)
+
+        if (!hasPolkadotNetwork(userConfig) || isTargetingEvm(userConfig)) {
+            return resolvedConfig
+        }
+
+        return {
+            ...resolvedConfig,
+            resolc: resolveResolcConfig(userConfig),
+        }
+    },
+})
+
+export default configHookHandler

--- a/packages/hardhat-polkadot-resolc/src/hook-handlers/hre.ts
+++ b/packages/hardhat-polkadot-resolc/src/hook-handlers/hre.ts
@@ -1,0 +1,23 @@
+import type { HardhatRuntimeEnvironmentHooks } from "hardhat/types/hooks"
+
+import { ResolcPluginError } from "../errors.js"
+
+const hreHookHandler: () => Promise<Partial<HardhatRuntimeEnvironmentHooks>> = async () => ({
+    created: async (_context, hre) => {
+        const resolc = hre.config.resolc
+        if (!resolc) return
+
+        if (resolc.compilerSource !== "npm") return
+
+        // Validate: npm compiler source doesn't support multiple solidity versions
+        for (const profile of Object.values(hre.config.solidity.profiles)) {
+            if (profile.compilers.length > 1 || Object.keys(profile.overrides).length > 0) {
+                throw new ResolcPluginError(
+                    `Multiple solidity versions are not available when using npm as the compiler.`,
+                )
+            }
+        }
+    },
+})
+
+export default hreHookHandler

--- a/packages/hardhat-polkadot-resolc/src/index.ts
+++ b/packages/hardhat-polkadot-resolc/src/index.ts
@@ -10,7 +10,10 @@ export { ResolcCompilerDownloader } from "./downloader.js"
 const hardhatPolkadotResolcPlugin: HardhatPlugin = {
     id: "hardhat-polkadot-resolc",
     npmPackage: "@parity/hardhat-polkadot-resolc",
-    hookHandlers: {},
+    hookHandlers: {
+        config: () => import("./hook-handlers/config.js"),
+        hre: () => import("./hook-handlers/hre.js"),
+    },
     tasks: [],
 }
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -30,14 +30,14 @@ importers:
         specifier: ^5.3.0
         version: 5.3.0
       '@parity/hardhat-polkadot-migrator':
-        specifier: workspace:*
-        version: link:../hardhat-polkadot-migrator
+        specifier: file:/home/bee344/Documentos/parity/revive/hardhat-polkadot/packages/hardhat-polkadot/.bundled/parity-hardhat-polkadot-migrator-0.1.0.tgz
+        version: file:packages/hardhat-polkadot/.bundled/parity-hardhat-polkadot-migrator-0.1.0.tgz(hardhat@3.1.12)
       '@parity/hardhat-polkadot-node':
-        specifier: workspace:*
-        version: link:../hardhat-polkadot-node
+        specifier: file:/home/bee344/Documentos/parity/revive/hardhat-polkadot/packages/hardhat-polkadot/.bundled/parity-hardhat-polkadot-node-0.2.4.tgz
+        version: file:packages/hardhat-polkadot/.bundled/parity-hardhat-polkadot-node-0.2.4.tgz(@types/node@22.15.24)(hardhat@3.1.12)(rxjs@7.8.2)(typescript@5.8.3)
       '@parity/hardhat-polkadot-resolc':
-        specifier: workspace:*
-        version: link:../hardhat-polkadot-resolc
+        specifier: file:/home/bee344/Documentos/parity/revive/hardhat-polkadot/packages/hardhat-polkadot/.bundled/parity-hardhat-polkadot-resolc-0.2.1.tgz
+        version: file:packages/hardhat-polkadot/.bundled/parity-hardhat-polkadot-resolc-0.2.1.tgz(@types/node@22.15.24)(hardhat@3.1.12)(typescript@5.8.3)
       chalk:
         specifier: '4'
         version: 4.1.2
@@ -1131,6 +1131,24 @@ packages:
 
   '@openzeppelin/contracts@5.3.0':
     resolution: {integrity: sha512-zj/KGoW7zxWUE8qOI++rUM18v+VeLTTzKs/DJFkSzHpQFPD/jKKF0TrMxBfGLl3kpdELCNccvB3zmofSzm4nlA==}
+
+  '@parity/hardhat-polkadot-migrator@file:packages/hardhat-polkadot/.bundled/parity-hardhat-polkadot-migrator-0.1.0.tgz':
+    resolution: {integrity: sha512-2hkFzDZ5KlF0BjjqWVNRrfG04gSXxABwGKqttXyBFZbWOye7D17MU7Gw8Oo9GRvaNoeFwQNGN4cHCy3hR1nTfg==, tarball: file:packages/hardhat-polkadot/.bundled/parity-hardhat-polkadot-migrator-0.1.0.tgz}
+    version: 0.1.0
+    peerDependencies:
+      hardhat: ^3.0.0
+
+  '@parity/hardhat-polkadot-node@file:packages/hardhat-polkadot/.bundled/parity-hardhat-polkadot-node-0.2.4.tgz':
+    resolution: {integrity: sha512-Kbt57SFzMKsymLqR4dT9p+3smrvVzFJqVJpuliJLorrNcmF8ZxlxC0sbkpGXD1Ni8g7TT1MHZU00uo2rUDTZ1A==, tarball: file:packages/hardhat-polkadot/.bundled/parity-hardhat-polkadot-node-0.2.4.tgz}
+    version: 0.2.4
+    peerDependencies:
+      hardhat: ^3.0.0
+
+  '@parity/hardhat-polkadot-resolc@file:packages/hardhat-polkadot/.bundled/parity-hardhat-polkadot-resolc-0.2.1.tgz':
+    resolution: {integrity: sha512-A12b1Q7psiqDOXEWTV7rejWasMtS3rSpQMA2SY7esGyqKBYrxFSE7QtGkYBb+Gixx4reOFFU8tfAWzJVrQqyXw==, tarball: file:packages/hardhat-polkadot/.bundled/parity-hardhat-polkadot-resolc-0.2.1.tgz}
+    version: 0.2.1
+    peerDependencies:
+      hardhat: ^3.0.0
 
   '@parity/resolc@0.3.0':
     resolution: {integrity: sha512-vWaKhqM89YH+Kn1y+0Kv92NG+0G7HktDhA3OdYvCoG320R4djpg/N/C9s90w/B0IWrRfaGR3Nk3R6O+VOBMjFA==}
@@ -4568,6 +4586,66 @@ snapshots:
 
   '@openzeppelin/contracts@5.3.0': {}
 
+  '@parity/hardhat-polkadot-migrator@file:packages/hardhat-polkadot/.bundled/parity-hardhat-polkadot-migrator-0.1.0.tgz(hardhat@3.1.12)':
+    dependencies:
+      hardhat: 3.1.12
+      jscodeshift: 17.3.0
+      semver: 7.7.2
+    transitivePeerDependencies:
+      - '@babel/preset-env'
+      - supports-color
+
+  '@parity/hardhat-polkadot-node@file:packages/hardhat-polkadot/.bundled/parity-hardhat-polkadot-node-0.2.4.tgz(@types/node@22.15.24)(hardhat@3.1.12)(rxjs@7.8.2)(typescript@5.8.3)':
+    dependencies:
+      axios: 1.9.0(debug@4.4.3)
+      chalk: 4.1.2
+      debug: 4.4.3
+      dockerode: 4.0.9
+      ethers: 6.15.0
+      fast-glob: 3.3.3
+      hardhat: 3.1.12
+      lru-cache: 11.1.0
+      polkadot-api: 1.15.2(rxjs@7.8.2)(tsx@4.21.0)(yaml@2.8.1)
+      run-container: 2.0.12
+      source-map-support: 0.5.21
+      ts-node: 10.9.2(@types/node@22.15.24)(typescript@5.8.3)
+    transitivePeerDependencies:
+      - '@microsoft/api-extractor'
+      - '@swc/core'
+      - '@swc/wasm'
+      - '@types/node'
+      - bufferutil
+      - jiti
+      - postcss
+      - rxjs
+      - supports-color
+      - tsx
+      - typescript
+      - utf-8-validate
+      - yaml
+
+  '@parity/hardhat-polkadot-resolc@file:packages/hardhat-polkadot/.bundled/parity-hardhat-polkadot-resolc-0.2.1.tgz(@types/node@22.15.24)(hardhat@3.1.12)(typescript@5.8.3)':
+    dependencies:
+      '@ethereumjs/util': 10.0.0
+      '@nomicfoundation/hardhat-errors': 3.0.8
+      '@nomicfoundation/hardhat-utils': 4.0.1
+      '@parity/resolc': 0.3.0(debug@4.4.3)
+      axios: 1.9.0(debug@4.4.3)
+      chalk: 4.1.2
+      debug: 4.4.3
+      find-up: 5.0.0
+      fs-extra: 11.3.0
+      fs-xattr: 0.4.0
+      hardhat: 3.1.12
+      semver: 7.7.2
+      ts-node: 10.9.2(@types/node@22.15.24)(typescript@5.8.3)
+    transitivePeerDependencies:
+      - '@swc/core'
+      - '@swc/wasm'
+      - '@types/node'
+      - supports-color
+      - typescript
+
   '@parity/resolc@0.3.0(debug@4.4.1)':
     dependencies:
       '@types/node': 22.17.0
@@ -4575,6 +4653,16 @@ snapshots:
       package-json: 10.0.1
       resolve-pkg: 2.0.0
       solc: 0.8.30(debug@4.4.1)
+    transitivePeerDependencies:
+      - debug
+
+  '@parity/resolc@0.3.0(debug@4.4.3)':
+    dependencies:
+      '@types/node': 22.17.0
+      commander: 13.1.0
+      package-json: 10.0.1
+      resolve-pkg: 2.0.0
+      solc: 0.8.30(debug@4.4.3)
     transitivePeerDependencies:
       - debug
 
@@ -5280,6 +5368,14 @@ snapshots:
     transitivePeerDependencies:
       - debug
 
+  axios@1.9.0(debug@4.4.3):
+    dependencies:
+      follow-redirects: 1.15.9(debug@4.4.3)
+      form-data: 4.0.2
+      proxy-from-env: 1.1.0
+    transitivePeerDependencies:
+      - debug
+
   balanced-match@1.0.2: {}
 
   base64-js@1.5.1: {}
@@ -5963,9 +6059,17 @@ snapshots:
     optionalDependencies:
       debug: 4.4.1
 
+  follow-redirects@1.15.11(debug@4.4.3):
+    optionalDependencies:
+      debug: 4.4.3
+
   follow-redirects@1.15.9(debug@4.4.1):
     optionalDependencies:
       debug: 4.4.1
+
+  follow-redirects@1.15.9(debug@4.4.3):
+    optionalDependencies:
+      debug: 4.4.3
 
   for-each@0.3.5:
     dependencies:
@@ -7078,6 +7182,18 @@ snapshots:
       command-exists: 1.2.9
       commander: 8.3.0
       follow-redirects: 1.15.11(debug@4.4.1)
+      js-sha3: 0.8.0
+      memorystream: 0.3.1
+      semver: 5.7.2
+      tmp: 0.0.33
+    transitivePeerDependencies:
+      - debug
+
+  solc@0.8.30(debug@4.4.3):
+    dependencies:
+      command-exists: 1.2.9
+      commander: 8.3.0
+      follow-redirects: 1.15.11(debug@4.4.3)
       js-sha3: 0.8.0
       memorystream: 0.3.1
       semver: 5.7.2


### PR DESCRIPTION
- Created `hook-handlers/config.ts` with three v3 config hooks:
  - `extendUserConfig`: merges `resolc` defaults (binary/npm) when polkadot networks are present
  - `validateUserConfig`: validates `compilerSource` and version fields
  - `resolveUserConfig`: calls `next()` then attaches resolved `resolc` to config
- Created `hook-handlers/hre.ts` with created hook:
  - Validates that npm compiler source isn't used with multiple solidity versions/overrides (adapted to v3's profiles structure)
- Updated index.ts — plugin definition now registers config and hre hook handlers via dynamic imports
- Added "type": "module" to package.json — required for NodeNext to correctly type dynamic import() of same-project ESM files