### PR TITLE
fix: update config extender

### DIFF
--- a/packages/hardhat-polkadot-node/src/hook-handlers/config.ts
+++ b/packages/hardhat-polkadot-node/src/hook-handlers/config.ts
@@ -1,6 +1,24 @@
 import type { ConfigHooks, HardhatUserConfigValidationError } from "hardhat/types/hooks"
 
 const configHookHandler: () => Promise<Partial<ConfigHooks>> = async () => ({
+    extendUserConfig: async (config, next) => {
+        const networks = config.networks ?? {}
+
+        // Ensure polkadot-enabled networks have the correct type for v3 validation.
+        // In v3, the default EDR network is "default" (not "hardhat"). If users
+        // define a "hardhat" network with polkadot config, we need to ensure it
+        // has a `type` field so the Zod discriminated union validates correctly.
+        for (const [, network] of Object.entries(networks)) {
+            if (!network || !("polkadot" in network) || !network.polkadot) continue
+            if (!("type" in network) || network.type === undefined) {
+                // eslint-disable-next-line @typescript-eslint/no-explicit-any
+                ;(network as any).type = "url" in network ? "http" : "edr-simulated"
+            }
+        }
+
+        return next({ ...config, networks })
+    },
+
     validateUserConfig: async (config) => {
         const errors: HardhatUserConfigValidationError[] = []
         const networks = config.networks ?? {}

--- a/packages/hardhat-polkadot-node/test/config-hook.test.ts
+++ b/packages/hardhat-polkadot-node/test/config-hook.test.ts
@@ -8,72 +8,115 @@ describe("config hook handler", () => {
         return handler.validateUserConfig!(config)
     }
 
-    it("returns no errors for valid config", async () => {
-        const errors = await validate({
-            networks: { hardhat: { polkadot: true } },
-        })
-        expect(errors).toEqual([])
-    })
+    async function extend(config: Record<string, unknown>) {
+        const handler = await configHookHandler()
+        const next = (c: any) => Promise.resolve(c)
+        return handler.extendUserConfig!(config, next)
+    }
 
-    it("returns no errors when no polkadot networks", async () => {
-        const errors = await validate({
-            networks: { hardhat: {} },
+    describe("validateUserConfig", () => {
+        it("returns no errors for valid config", async () => {
+            const errors = await validate({
+                networks: { hardhat: { polkadot: true } },
+            })
+            expect(errors).toEqual([])
         })
-        expect(errors).toEqual([])
-    })
 
-    it("returns no errors for polkadot object config", async () => {
-        const errors = await validate({
-            networks: { hardhat: { polkadot: { target: "evm" } } },
+        it("returns no errors when no polkadot networks", async () => {
+            const errors = await validate({
+                networks: { hardhat: {} },
+            })
+            expect(errors).toEqual([])
         })
-        expect(errors).toEqual([])
-    })
 
-    it("returns error for invalid polkadot type", async () => {
-        const errors = await validate({
-            networks: { hardhat: { polkadot: "invalid" } },
+        it("returns no errors for polkadot object config", async () => {
+            const errors = await validate({
+                networks: { hardhat: { polkadot: { target: "evm" } } },
+            })
+            expect(errors).toEqual([])
         })
-        expect(errors).toHaveLength(1)
-        expect(errors[0].path).toEqual(["networks", "hardhat", "polkadot"])
-    })
 
-    it("returns error for non-numeric rpcPort", async () => {
-        const errors = await validate({
-            networks: { hardhat: { polkadot: true, nodeConfig: { rpcPort: "abc" } } },
+        it("returns error for invalid polkadot type", async () => {
+            const errors = await validate({
+                networks: { hardhat: { polkadot: "invalid" } },
+            })
+            expect(errors).toHaveLength(1)
+            expect(errors[0].path).toEqual(["networks", "hardhat", "polkadot"])
         })
-        expect(errors).toHaveLength(1)
-        expect(errors[0].path).toEqual(["networks", "hardhat", "nodeConfig", "rpcPort"])
-    })
 
-    it("returns error for non-numeric adapterPort", async () => {
-        const errors = await validate({
-            networks: { hardhat: { polkadot: true, adapterConfig: { adapterPort: "abc" } } },
+        it("returns error for non-numeric rpcPort", async () => {
+            const errors = await validate({
+                networks: { hardhat: { polkadot: true, nodeConfig: { rpcPort: "abc" } } },
+            })
+            expect(errors).toHaveLength(1)
+            expect(errors[0].path).toEqual(["networks", "hardhat", "nodeConfig", "rpcPort"])
         })
-        expect(errors).toHaveLength(1)
-        expect(errors[0].path).toEqual(["networks", "hardhat", "adapterConfig", "adapterPort"])
-    })
 
-    it("returns error when adapter and node share the same port", async () => {
-        const errors = await validate({
-            networks: {
-                hardhat: {
-                    polkadot: true,
-                    nodeConfig: { rpcPort: 9944 },
-                    adapterConfig: { adapterPort: 9944 },
+        it("returns error for non-numeric adapterPort", async () => {
+            const errors = await validate({
+                networks: { hardhat: { polkadot: true, adapterConfig: { adapterPort: "abc" } } },
+            })
+            expect(errors).toHaveLength(1)
+            expect(errors[0].path).toEqual([
+                "networks",
+                "hardhat",
+                "adapterConfig",
+                "adapterPort",
+            ])
+        })
+
+        it("returns error when adapter and node share the same port", async () => {
+            const errors = await validate({
+                networks: {
+                    hardhat: {
+                        polkadot: true,
+                        nodeConfig: { rpcPort: 9944 },
+                        adapterConfig: { adapterPort: 9944 },
+                    },
                 },
-            },
+            })
+            expect(errors).toHaveLength(1)
+            expect(errors[0].message).toContain("cannot share the same port")
         })
-        expect(errors).toHaveLength(1)
-        expect(errors[0].message).toContain("cannot share the same port")
+
+        it("handles empty networks", async () => {
+            const errors = await validate({ networks: {} })
+            expect(errors).toEqual([])
+        })
+
+        it("handles missing networks", async () => {
+            const errors = await validate({})
+            expect(errors).toEqual([])
+        })
     })
 
-    it("handles empty networks", async () => {
-        const errors = await validate({ networks: {} })
-        expect(errors).toEqual([])
-    })
+    describe("extendUserConfig", () => {
+        it("adds edr-simulated type to polkadot network without type", async () => {
+            const result = await extend({
+                networks: { hardhat: { polkadot: true } },
+            })
+            expect(result.networks.hardhat.type).toBe("edr-simulated")
+        })
 
-    it("handles missing networks", async () => {
-        const errors = await validate({})
-        expect(errors).toEqual([])
+        it("adds http type to polkadot network with url", async () => {
+            const result = await extend({
+                networks: { testnet: { polkadot: true, url: "https://example.com" } },
+            })
+            expect(result.networks.testnet.type).toBe("http")
+        })
+
+        it("does not overwrite existing type", async () => {
+            const result = await extend({
+                networks: { hardhat: { polkadot: true, type: "http" } },
+            })
+            expect(result.networks.hardhat.type).toBe("http")
+        })
+
+        it("does not add type to non-polkadot networks", async () => {
+            const result = await extend({
+                networks: { mainnet: { url: "https://example.com" } },
+            })
+            expect(result.networks.mainnet.type).toBeUndefined()
+        })
     })
 })

--- a/packages/hardhat-polkadot-resolc/src/downloader.ts
+++ b/packages/hardhat-polkadot-resolc/src/downloader.ts
@@ -67,14 +67,16 @@ export class ResolcCompilerDownloader implements IResolcCompilerDownloader {
     }
 
     public static defaultCompilerListCachePeriod = 3_600_00
-    private readonly _mutex = new MultiProcessMutex("compiler-download")
+    private readonly _mutex: MultiProcessMutex
 
     constructor(
         private readonly _platform: CompilerPlatform,
         private readonly _compilersDir: string,
         private readonly _compilerListCachePeriodMs = ResolcCompilerDownloader.defaultCompilerListCachePeriod,
         private readonly _downloadFunction: typeof download = download,
-    ) {}
+    ) {
+        this._mutex = new MultiProcessMutex(path.join(_compilersDir, "compiler-download"))
+    }
 
     public async isCompilerDownloaded(version: string): Promise<boolean> {
         const build = await this._getCompilerBuild(version)

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -7,13 +7,9 @@ export default defineConfig({
             "packages/*/test/**/*.test.ts",
             "tests/e2e/**/*.test.ts",
         ],
-        testTimeout: 10000,
-        pool: "forks",
-        poolOptions: {
-            forks: {
-                singleFork: true,
-            },
-        },
+        testTimeout: 120000,
+        hookTimeout: 120000,
         teardownTimeout: 30000,
+        fileParallelism: false,
     },
 })


### PR DESCRIPTION
- Added `extendUserConfig` hook that injects type: "edr-simulated" or type: "http" on polkadot-enabled networks so Hardhat v3's Zod discriminated union validates correctly
- Fixed `compiler-download` relative path to absolute path in the downloader constructor