### PR TITLE
fix: miscelaneous bugs

### DIFF
--- a/packages/hardhat-polkadot-migrator/src/index.ts
+++ b/packages/hardhat-polkadot-migrator/src/index.ts
@@ -46,9 +46,13 @@ export async function updatePackageJSON(projectPath: string): Promise<[string, s
     // Fetch latest `@parity/hardhat-polkadot` module metadata from npm registry
     // We allow "Fetch failed" error to bubble up, or throw a custom error in case
     // of a successful but invalid response
-    const moduleMetadata = (await (
-        await fetch(`https://registry.npmjs.org/${MODULE}/latest`)
-    ).json()) as {
+    const response = await fetch(`https://registry.npmjs.org/${MODULE}/latest`)
+    if (!response.ok) {
+        throw new Error(
+            `Failed to fetch ${MODULE} metadata from npm registry (HTTP ${response.status})`,
+        )
+    }
+    const moduleMetadata = (await response.json()) as {
         version: string
         peerDependencies: { hardhat: string }
     }

--- a/packages/hardhat-polkadot-node/src/rpc-server.ts
+++ b/packages/hardhat-polkadot-node/src/rpc-server.ts
@@ -28,7 +28,7 @@ export function createRpcServer(opts: {
             }
         },
 
-        listen(
+        async listen(
             nodeArgs: string[] = [],
             adapterArgs: string[] = [],
             blockProcess = true,
@@ -67,7 +67,7 @@ export function createRpcServer(opts: {
             if (opts.docker && opts.isForking) {
                 const docker = new Docker({ socketPath: getDockerSocketPath(opts.docker) })
 
-                chopsticksService.from_binary("")
+                await chopsticksService.from_binary("")
                 return ethRpcService.from_docker(docker, chopsticksService.port)
             }
 

--- a/packages/hardhat-polkadot-node/src/rpc-server.ts
+++ b/packages/hardhat-polkadot-node/src/rpc-server.ts
@@ -28,7 +28,7 @@ export function createRpcServer(opts: {
             }
         },
 
-        async listen(
+        listen(
             nodeArgs: string[] = [],
             adapterArgs: string[] = [],
             blockProcess = true,
@@ -67,8 +67,9 @@ export function createRpcServer(opts: {
             if (opts.docker && opts.isForking) {
                 const docker = new Docker({ socketPath: getDockerSocketPath(opts.docker) })
 
-                await chopsticksService.from_binary("")
-                return ethRpcService.from_docker(docker, chopsticksService.port)
+                return chopsticksService
+                    .from_binary("")
+                    .then(() => ethRpcService.from_docker(docker, chopsticksService.port))
             }
 
             throw new PolkadotNodePluginError(

--- a/packages/hardhat-polkadot-node/src/utils.ts
+++ b/packages/hardhat-polkadot-node/src/utils.ts
@@ -74,12 +74,6 @@ export function constructCommandArgs(args?: CommandArguments): SplitCommands {
             throw new PolkadotNodePluginError("Adapter and node cannot share the same port.")
         }
 
-        if (
-            args.adapterCommands?.adapterPort &&
-            args.adapterCommands?.adapterPort === args.nodeCommands?.rpcPort
-        ) {
-            throw new PolkadotNodePluginError("Adapter and node cannot share the same port.")
-        }
         if (args.forking) {
             nodeCommands.push(
                 `--build-block-mode=${args.adapterCommands?.buildBlockMode || "Instant"}`,
@@ -192,7 +186,7 @@ export async function configureNetwork(
     try {
         const response = await axios.post(url, payload)
 
-        if (response.status == 200) {
+        if (response.status === 200) {
             _chainId = parseInt(response.data.result)
         }
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -261,7 +255,7 @@ export async function getLatestImageName(containerName: string): Promise<string 
         responseType: "json",
     })
 
-    if (imageResponse.status == 200) {
+    if (imageResponse.status === 200) {
         const imageList = imageResponse.data
 
         imageList.results
@@ -312,7 +306,7 @@ export async function waitForServiceToBeReady(
         try {
             const response = await axios.post(endpoint, payload)
 
-            if (response.status == 200) {
+            if (response.status === 200) {
                 return
             }
             // eslint-disable-next-line @typescript-eslint/no-explicit-any

--- a/packages/hardhat-polkadot-resolc/src/compile/binary.ts
+++ b/packages/hardhat-polkadot-resolc/src/compile/binary.ts
@@ -43,6 +43,14 @@ export async function compileWithBinary(
         let output = ""
         let error = ""
 
+        process.on("error", (err) => {
+            reject(new ResolcPluginError(`Failed to spawn resolc: ${err.message}`))
+        })
+
+        process.stdin.on("error", (err) => {
+            reject(new ResolcPluginError(`Failed to write to resolc stdin: ${err.message}`))
+        })
+
         process.stdin.write(inputs)
         process.stdin.end()
 
@@ -59,8 +67,8 @@ export async function compileWithBinary(
                 try {
                     const result = JSON.parse(output)
                     resolve(result)
-                } catch {
-                    reject(new ResolcPluginError(`Failed to parse output`))
+                } catch (e) {
+                    reject(new ResolcPluginError(`Failed to parse resolc output: ${(e as Error).message}`))
                 }
             } else {
                 reject(new ResolcPluginError(`Process exited with code ${code}: ${error}`))

--- a/packages/hardhat-polkadot-resolc/src/compile/npm.ts
+++ b/packages/hardhat-polkadot-resolc/src/compile/npm.ts
@@ -1,13 +1,10 @@
 import path from "path"
-import { exec as execCb, execSync } from "child_process"
-import { promisify } from "util"
+import { execSync } from "child_process"
 import semver from "semver"
 import { compile, resolveInputs, type SolcOutput } from "@parity/resolc"
 import type { CompilerInput } from "hardhat/types/solidity"
 import type { ResolcConfig } from "../types.js"
 import { ResolcPluginError } from "../errors.js"
-
-const _exec = promisify(execCb)
 
 export async function compileWithNpm(
     input: CompilerInput,

--- a/packages/hardhat-polkadot-resolc/src/download.ts
+++ b/packages/hardhat-polkadot-resolc/src/download.ts
@@ -2,7 +2,6 @@ import fsExtra from "fs-extra"
 import path from "path"
 
 import axios from "axios"
-import { execSync } from "child_process"
 import { CompilerPlatform, CompilerName, type CompilerBuild, type CompilerList } from "./types.js"
 import { COMPILER_REPOSITORY_URL } from "./constants.js"
 
@@ -61,11 +60,11 @@ export async function download(
                 const longVersion = `${version}+commit.${commit}.llvm-18.1.8`
 
                 // eslint-disable-next-line @typescript-eslint/no-explicit-any
-                const asset = release.assets.find((a: any) => a.name == name)
+                const asset = release.assets.find((a: any) => a.name === name)
                 if (!asset) continue
 
                 let sha256 = ""
-                if (!asset.digest || asset.digest == null) {
+                if (!asset.digest) {
                     const checksumResponse = await axios.get(
                         `${COMPILER_REPOSITORY_URL}v${version}/checksums.txt`,
                         {
@@ -74,18 +73,12 @@ export async function download(
                         },
                     )
 
-                    const tempFile = `./${TEMP_FILE_PREFIX}checksums.txt`
-                    fsExtra.writeFileSync(tempFile, checksumResponse.data)
-                    try {
-                        const checksum = execSync(`grep ${name} ${tempFile}`).toString()
-                        sha256 = checksum.trim().split(" ")[0]
-
-                        fsExtra.remove(tempFile, (removeErr) => {
-                            if (removeErr) console.error("Failed to delete temp file:", removeErr)
-                        })
-                    } catch (e) {
-                        return console.error("grep failed:", e)
+                    const checksumLines = (checksumResponse.data as string).split("\n")
+                    const matchingLine = checksumLines.find((line: string) => line.includes(name))
+                    if (!matchingLine) {
+                        throw new Error(`Checksum not found for ${name} in v${version}`)
                     }
+                    sha256 = matchingLine.trim().split(" ")[0]
                 } else {
                     sha256 = asset.digest.slice(7)
                 }

--- a/packages/hardhat-polkadot/src/cli/file-utils.ts
+++ b/packages/hardhat-polkadot/src/cli/file-utils.ts
@@ -49,10 +49,10 @@ async function readdir(absolutePathToDir: string) {
         }
 
         if (error.code === "ENOTDIR") {
-            throw new Error(absolutePathToDir, error)
+            throw new Error(absolutePathToDir, { cause: error })
         }
 
-        throw new Error(error.message, error)
+        throw new Error(error.message, { cause: error })
     }
 }
 
@@ -75,7 +75,7 @@ export async function addOrMergeGitIgnore(projectRoot: string): Promise<[string,
     const newLines = newContent.split(/\r?\n/)
     let keepLines = newLines.filter(
         (line) =>
-            line == "" ||
+            line === "" ||
             line.startsWith("#") ||
             !(
                 existingLines.includes(line) ||
@@ -93,7 +93,7 @@ export async function addOrMergeGitIgnore(projectRoot: string): Promise<[string,
 
     // Merge old & new content
     let newGitIgnore = originalGitIgnore
-    if (originalGitIgnore != "") {
+    if (originalGitIgnore !== "") {
         newGitIgnore = newGitIgnore.trimEnd() + "\n\n"
     }
     if (keepLines.length > 0) {


### PR DESCRIPTION
#### Fixes bugs and error handling issues found during a code audit across all packages.
##### Async/process handling:
- replace `execFile` with `execFileSync` in a try/catch that expected synchronous errors
- Missing await on `chopsticksService.from_binary()` caused a race condition where the ETH-RPC adapter started before chopsticks was ready
- Added missing `process.on('error')` and `stdin.on('error')` handlers on spawned `resolc` process
##### Silent error swallowing:
- `return console.error("grep failed:", e)` silently returned `undefined`, aborting the compiler list build without throwing
- `new Error(msg, error)`'s second arg to `Error()` was silently dropped; fixed to `{ cause: error }`
- JSON parse failure lost the actual error message whgen compiling with binary
- npm registry fetch didn't check `response.ok`, so HTTP 404/500 produced a weird JSON parse error instead of a clear message
##### Shell injection / cleanup:
- Replaced `execSync(\grep ${name} ${tempFile})` with in-memory string search to prevent shell injection
##### Dead code:
- Removed duplicate unreachable port-conflict check
- Removed unused `_exec = promisify(execCb)`
#### Strict equality:
- `==` / `!=` refactored to `===` / `!==`