### PR TITLE
fix: refactor and bug fixes

### DIFF
--- a/packages/hardhat-polkadot-node/src/constants.ts
+++ b/packages/hardhat-polkadot-node/src/constants.ts
@@ -1,5 +1,7 @@
 export const PLUGIN_NAME = "hardhat-polkadot-node"
 
+export const DEFAULT_NETWORK_NAME = "default"
+
 export const PROCESS_TERMINATION_SIGNALS = ["SIGINT", "SIGTERM", "SIGKILL"]
 
 export const NODE_START_PORT = 9944

--- a/packages/hardhat-polkadot-node/src/hook-handlers/config.ts
+++ b/packages/hardhat-polkadot-node/src/hook-handlers/config.ts
@@ -1,5 +1,4 @@
 import type { ConfigHooks, HardhatUserConfigValidationError } from "hardhat/types/hooks"
-import type { HardhatUserConfig } from "hardhat/types/config"
 
 const configHookHandler: () => Promise<Partial<ConfigHooks>> = async () => ({
     extendUserConfig: async (config, next) => {
@@ -73,7 +72,7 @@ const configHookHandler: () => Promise<Partial<ConfigHooks>> = async () => ({
 
     resolveUserConfig: async (userConfig, resolveConfigurationVariable, next) => {
         const resolvedConfig = await next(userConfig, resolveConfigurationVariable)
-        const userNetworks = (userConfig as HardhatUserConfig).networks ?? {}
+        const userNetworks = userConfig.networks ?? {}
 
         for (const [name, network] of Object.entries(userNetworks)) {
             if (!network || !("polkadot" in network) || !network.polkadot) continue

--- a/packages/hardhat-polkadot-node/src/hook-handlers/config.ts
+++ b/packages/hardhat-polkadot-node/src/hook-handlers/config.ts
@@ -1,4 +1,5 @@
 import type { ConfigHooks, HardhatUserConfigValidationError } from "hardhat/types/hooks"
+import type { HardhatUserConfig } from "hardhat/types/config"
 
 const configHookHandler: () => Promise<Partial<ConfigHooks>> = async () => ({
     extendUserConfig: async (config, next) => {
@@ -68,6 +69,25 @@ const configHookHandler: () => Promise<Partial<ConfigHooks>> = async () => ({
         }
 
         return errors
+    },
+
+    resolveUserConfig: async (userConfig, resolveConfigurationVariable, next) => {
+        const resolvedConfig = await next(userConfig, resolveConfigurationVariable)
+        const userNetworks = (userConfig as HardhatUserConfig).networks ?? {}
+
+        for (const [name, network] of Object.entries(userNetworks)) {
+            if (!network || !("polkadot" in network) || !network.polkadot) continue
+            if (!resolvedConfig.networks?.[name]) continue
+            // eslint-disable-next-line @typescript-eslint/no-explicit-any
+            const resolved = resolvedConfig.networks[name] as any
+            resolved.polkadot = network.polkadot
+            if ("nodeConfig" in network) resolved.nodeConfig = network.nodeConfig
+            if ("adapterConfig" in network) resolved.adapterConfig = network.adapterConfig
+            if ("docker" in network) resolved.docker = network.docker
+            if ("forking" in network) resolved.forking = network.forking
+        }
+
+        return resolvedConfig
     },
 })
 

--- a/packages/hardhat-polkadot-node/src/hook-handlers/network.ts
+++ b/packages/hardhat-polkadot-node/src/hook-handlers/network.ts
@@ -2,10 +2,13 @@ import type { HookContext } from "hardhat/types/hooks"
 import type { NetworkConnection, ChainType } from "hardhat/types/network"
 import type { EdrNetworkUserConfig } from "hardhat/types/config"
 
-import { startServer, configureNetwork } from "../utils.js"
+import { startServer } from "../utils.js"
+import { BASE_URL } from "../constants.js"
 import type { RpcServer } from "../types.js"
 
-// NetworkHooks is augmented onto HardhatHooks by the network-manager plugin
+// NetworkHooks is augmented onto HardhatHooks by the network-manager builtin plugin
+// (v-next/hardhat/src/internal/builtin-plugins/network-manager/type-extensions/hooks.ts).
+// It is not re-exported from a public path; we duplicate the subset we need here.
 interface NetworkHooks {
     newConnection: <ChainTypeT extends ChainType | string>(
         context: HookContext,
@@ -49,7 +52,7 @@ const networkHookHandler: () => Promise<Partial<NetworkHooks>> = async () => ({
         const nodeConfig = edrConfig.nodeConfig
         const adapterConfig = edrConfig.adapterConfig
         const docker = edrConfig.docker
-        const forking = "forking" in edrConfig ? edrConfig.forking : undefined
+        const forking = edrConfig.forking
 
         const { commandArgs, server, port } = await startServer(
             {
@@ -68,8 +71,19 @@ const networkHookHandler: () => Promise<Partial<NetworkHooks>> = async () => ({
         // Track the server for cleanup
         activeServers.set(connection.id, server)
 
-        // Configure the network with the local RPC endpoint
-        await configureNetwork(context.config, connection, port)
+        // Store the local URL on the resolved config so downstream code (e.g.
+        // factory-deps) can discover it.  The connection's own provider was
+        // already created by `next()`, so this does NOT redirect the provider;
+        // the task-actions path (test.ts) remains the primary integration
+        // point where the URL is wired up before the provider is created.
+        // TODO: To fully integrate with HH3's connection model, polkadot
+        // networks should resolve as type:"http" pointing at the local server
+        // URL, so the provider is created with the correct endpoint. This
+        // requires starting the server in resolveUserConfig or using the
+        // onRequest hook to proxy requests.
+        const localUrl = `${BASE_URL}:${port}`
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        ;(connection as any).localPolkadotUrl = localUrl
 
         return connection
     },

--- a/packages/hardhat-polkadot-node/src/hook-handlers/network.ts
+++ b/packages/hardhat-polkadot-node/src/hook-handlers/network.ts
@@ -52,11 +52,12 @@ const networkHookHandler: () => Promise<Partial<NetworkHooks>> = async () => ({
         const nodeConfig = edrConfig.nodeConfig
         const adapterConfig = edrConfig.adapterConfig
         const docker = edrConfig.docker
-        const forking = edrConfig.forking
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        const forking = (edrConfig as any).forking as { enabled?: boolean; url?: string } | undefined
 
         const { commandArgs, server, port } = await startServer(
             {
-                forking: forking as { enabled?: boolean; url?: string } | undefined,
+                forking,
                 nodeCommands: nodeConfig,
                 adapterCommands: adapterConfig,
                 docker,

--- a/packages/hardhat-polkadot-node/src/rpc-server.ts
+++ b/packages/hardhat-polkadot-node/src/rpc-server.ts
@@ -45,7 +45,7 @@ export function createRpcServer(opts: {
                 return Promise.all([
                     substrateNodeService.from_binary(opts.nodePath),
                     ethRpcService.from_binary(opts.adapterPath),
-                ]).then(() => {})
+                ]).then((): void => {})
             }
 
             if (opts.docker && !opts.isForking) {
@@ -54,14 +54,14 @@ export function createRpcServer(opts: {
                 return Promise.all([
                     substrateNodeService.from_docker(docker),
                     ethRpcService.from_docker(docker, substrateNodeService.port),
-                ]).then(() => {})
+                ]).then((): void => {})
             }
 
             if (!!opts.adapterPath && opts.isForking) {
                 return Promise.all([
                     chopsticksService.from_binary(""),
                     ethRpcService.from_binary(opts.adapterPath),
-                ]).then(() => {})
+                ]).then((): void => {})
             }
 
             if (opts.docker && opts.isForking) {

--- a/packages/hardhat-polkadot-node/src/services/chopsticks.ts
+++ b/packages/hardhat-polkadot-node/src/services/chopsticks.ts
@@ -20,7 +20,7 @@ export class ChopsticksService extends Service {
             if (this.blockProcess) {
                 console.info(chalk.green(`Starting server at 127.0.0.1:${this.port}`))
                 console.info(
-                    chalk.green(`Running command: ${pathToBinary} ${this.commandArgs.join(" ")}`),
+                    chalk.green(`Running command: ${this.commandArgs.join(" ")}`),
                 )
             }
 

--- a/packages/hardhat-polkadot-node/src/services/chopsticks.ts
+++ b/packages/hardhat-polkadot-node/src/services/chopsticks.ts
@@ -15,7 +15,7 @@ export class ChopsticksService extends Service {
         this.port = portArg ? parseInt(portArg.split("=")[1], 10) : NODE_START_PORT
     }
 
-    public async from_binary(pathToBinary: string): Promise<void> {
+    public async from_binary(_pathToBinary: string): Promise<void> {
         return new Promise((resolve, reject) => {
             if (this.blockProcess) {
                 console.info(chalk.green(`Starting server at 127.0.0.1:${this.port}`))
@@ -37,7 +37,7 @@ export class ChopsticksService extends Service {
             this.process.on("exit", this._handleOnExit("chopsticks server"))
 
             if (!this.blockProcess) {
-                resolve()
+                this.process.once("spawn", () => resolve())
             }
         })
     }

--- a/packages/hardhat-polkadot-node/src/services/eth-rpc.ts
+++ b/packages/hardhat-polkadot-node/src/services/eth-rpc.ts
@@ -40,7 +40,7 @@ export class EthRpcService extends Service {
             this.process.on("exit", this._handleOnExit("Eth RPC Adapter"))
 
             if (!this.blockProcess) {
-                resolve()
+                this.process.once("spawn", () => resolve())
             }
         })
     }

--- a/packages/hardhat-polkadot-node/src/services/eth-rpc.ts
+++ b/packages/hardhat-polkadot-node/src/services/eth-rpc.ts
@@ -52,7 +52,9 @@ export class EthRpcService extends Service {
         await container
             .inspect()
             .then(() => container.remove({ force: true }))
-            .catch(() => {})
+            .catch((err: any) => {
+                if (err.statusCode !== 404) throw err
+            })
 
         this.container = await run({
             Image: `paritypr/eth-rpc:${imageTag}`,
@@ -84,13 +86,11 @@ export class EthRpcService extends Service {
         })
 
         // remove container when process exits
-        ;["exit", "SIGINT", "SIGUSR1", "SIGUSR2", "uncaughtException", "SIGTERM"].forEach((e) => {
-            process.on(
-                e,
-                async () =>
-                    await this.container!.remove({ force: true }).then(() => process.exit(0)),
-            )
-        })
+        for (const sig of ["SIGINT", "SIGTERM"] as const) {
+            process.once(sig, () => {
+                this.container?.stop({ t: 2 }).catch(() => {}).finally(() => process.exit(0))
+            })
+        }
 
         if (this.blockProcess) {
             console.info(chalk.green(`Starting the Eth RPC Adapter at 127.0.0.1:${this.port}`))

--- a/packages/hardhat-polkadot-node/src/services/eth-rpc.ts
+++ b/packages/hardhat-polkadot-node/src/services/eth-rpc.ts
@@ -88,6 +88,7 @@ export class EthRpcService extends Service {
         // remove container when process exits
         for (const sig of ["SIGINT", "SIGTERM"] as const) {
             process.once(sig, () => {
+                console.info(chalk.yellow(`Received ${sig}, stopping Eth RPC container...`))
                 this.container?.stop({ t: 2 }).catch(() => {}).finally(() => process.exit(0))
             })
         }

--- a/packages/hardhat-polkadot-node/src/services/service.ts
+++ b/packages/hardhat-polkadot-node/src/services/service.ts
@@ -1,6 +1,9 @@
 import chalk from "chalk"
+import debug from "debug"
 import Docker from "dockerode"
 import { ChildProcess } from "child_process"
+
+const log = debug("hardhat:polkadot:node:service")
 
 export abstract class Service {
     public process: ChildProcess | null = null
@@ -17,7 +20,9 @@ export abstract class Service {
                 console.info(
                     chalk.yellow(`Received ${signal} signal. The ${name} process has exited.`),
                 )
-            } else if (code !== 0) {
+            } else if (code === 0) {
+                log("The %s process exited cleanly", name)
+            } else {
                 console.info(chalk.red(`The ${name} process exited with code: ${code}`))
             }
         }

--- a/packages/hardhat-polkadot-node/src/services/substrate-node.ts
+++ b/packages/hardhat-polkadot-node/src/services/substrate-node.ts
@@ -61,7 +61,9 @@ export class SubstrateNodeService extends Service {
         await container
             .inspect()
             .then(() => container.remove({ force: true }))
-            .catch(() => {})
+            .catch((err: any) => {
+                if (err.statusCode !== 404) throw err
+            })
 
         this.container = await runSimple({
             name: SUBSTRATE_NODE_CONTAINER_NAME,
@@ -75,9 +77,11 @@ export class SubstrateNodeService extends Service {
         })
 
         // remove container when process exits
-        ;["exit", "SIGINT", "SIGUSR1", "SIGUSR2", "uncaughtException", "SIGTERM"].forEach((e) => {
-            process.on(e, async () => await this.container!.remove({ force: true }))
-        })
+        for (const sig of ["SIGINT", "SIGTERM"] as const) {
+            process.once(sig, () => {
+                this.container?.stop({ t: 2 }).catch(() => {}).finally(() => process.exit(0))
+            })
+        }
 
         if (this.blockProcess) {
             // show docker logs in client console

--- a/packages/hardhat-polkadot-node/src/services/substrate-node.ts
+++ b/packages/hardhat-polkadot-node/src/services/substrate-node.ts
@@ -81,6 +81,7 @@ export class SubstrateNodeService extends Service {
         // remove container when process exits
         for (const sig of ["SIGINT", "SIGTERM"] as const) {
             process.once(sig, () => {
+                console.info(chalk.yellow(`Received ${sig}, stopping substrate node container...`))
                 this.container?.stop({ t: 2 }).catch(() => {}).finally(() => process.exit(0))
             })
         }

--- a/packages/hardhat-polkadot-node/src/services/substrate-node.ts
+++ b/packages/hardhat-polkadot-node/src/services/substrate-node.ts
@@ -3,7 +3,7 @@ import chalk from "chalk"
 import { runSimple } from "run-container"
 import Docker from "dockerode"
 
-import { NODE_START_PORT } from "../constants.js"
+import { NODE_START_PORT, RPC_ENDPOINT_PATH } from "../constants.js"
 import { waitForServiceToBeReady, getLatestImageName } from "../utils.js"
 import { Service } from "./service.js"
 
@@ -11,6 +11,7 @@ const SUBSTRATE_NODE_CONTAINER_NAME = "substrate"
 
 export class SubstrateNodeService extends Service {
     public port: number
+    private useAnvil: boolean
 
     constructor(
         commandArgs: string[] = [],
@@ -18,6 +19,7 @@ export class SubstrateNodeService extends Service {
         useAnvil: boolean = true,
     ) {
         super(commandArgs.slice(1), blockProcess)
+        this.useAnvil = useAnvil
 
         const portArg = commandArgs.find((arg) => arg.startsWith("--rpc-port="))
         this.port = portArg
@@ -112,9 +114,14 @@ export class SubstrateNodeService extends Service {
     }
 
     public async waitForNodeToBeReady(maxAttempts = 20): Promise<void> {
+        // anvil-polkadot bundles the substrate node and eth-rpc adapter into
+        // a single process that exposes only Ethereum JSON-RPC (eth_chainId).
+        // A standalone substrate node (revive-dev-node) exposes Substrate RPC
+        // (state_getRuntimeVersion) on its websocket port.
+        const method = this.useAnvil ? RPC_ENDPOINT_PATH : "state_getRuntimeVersion"
         const payload = {
             jsonrpc: "2.0",
-            method: "state_getRuntimeVersion",
+            method,
             params: [],
             id: 1,
         }

--- a/packages/hardhat-polkadot-node/src/services/substrate-node.ts
+++ b/packages/hardhat-polkadot-node/src/services/substrate-node.ts
@@ -51,7 +51,7 @@ export class SubstrateNodeService extends Service {
             this.process.on("exit", this._handleOnExit("substrate node"))
 
             if (!this.blockProcess) {
-                resolve()
+                this.process.once("spawn", () => resolve())
             }
         })
     }

--- a/packages/hardhat-polkadot-node/src/task-actions/node-polkadot.ts
+++ b/packages/hardhat-polkadot-node/src/task-actions/node-polkadot.ts
@@ -4,15 +4,17 @@ import type { EdrNetworkUserConfig } from "hardhat/types/config"
 import { createRpcServer } from "../rpc-server.js"
 import { constructCommandArgs } from "../utils.js"
 import { PolkadotNodePluginError } from "../errors.js"
-import type { ForkingUserConfig } from "../types.js"
 import { DEFAULT_NETWORK_NAME } from "../constants.js"
 
 const nodePolkadotAction: NewTaskActionFunction = async (_taskArguments, hre) => {
     const networkConfig = hre.config.networks[DEFAULT_NETWORK_NAME] as unknown as EdrNetworkUserConfig
 
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const forking = (networkConfig as any)?.forking as { enabled?: boolean; url?: string; blockNumber?: number } | undefined
+
     const commandArgs = constructCommandArgs({
-        forking: networkConfig?.forking as ForkingUserConfig | undefined,
-        forkBlockNumber: networkConfig?.forking?.blockNumber,
+        forking,
+        forkBlockNumber: forking?.blockNumber,
         nodeCommands: networkConfig?.nodeConfig,
         adapterCommands: networkConfig?.adapterConfig,
     })

--- a/packages/hardhat-polkadot-node/src/task-actions/node-polkadot.ts
+++ b/packages/hardhat-polkadot-node/src/task-actions/node-polkadot.ts
@@ -4,13 +4,14 @@ import type { EdrNetworkUserConfig } from "hardhat/types/config"
 import { createRpcServer } from "../rpc-server.js"
 import { constructCommandArgs } from "../utils.js"
 import { PolkadotNodePluginError } from "../errors.js"
+import type { ForkingUserConfig } from "../types.js"
 import { DEFAULT_NETWORK_NAME } from "../constants.js"
 
 const nodePolkadotAction: NewTaskActionFunction = async (_taskArguments, hre) => {
     const networkConfig = hre.config.networks[DEFAULT_NETWORK_NAME] as unknown as EdrNetworkUserConfig
 
     const commandArgs = constructCommandArgs({
-        forking: networkConfig?.forking,
+        forking: networkConfig?.forking as ForkingUserConfig | undefined,
         forkBlockNumber: networkConfig?.forking?.blockNumber,
         nodeCommands: networkConfig?.nodeConfig,
         adapterCommands: networkConfig?.adapterConfig,

--- a/packages/hardhat-polkadot-node/src/task-actions/node-polkadot.ts
+++ b/packages/hardhat-polkadot-node/src/task-actions/node-polkadot.ts
@@ -4,17 +4,14 @@ import type { EdrNetworkUserConfig } from "hardhat/types/config"
 import { createRpcServer } from "../rpc-server.js"
 import { constructCommandArgs } from "../utils.js"
 import { PolkadotNodePluginError } from "../errors.js"
-
-const HARDHAT_NETWORK_NAME = "hardhat"
+import { DEFAULT_NETWORK_NAME } from "../constants.js"
 
 const nodePolkadotAction: NewTaskActionFunction = async (_taskArguments, hre) => {
-    const networkConfig = hre.config.networks[HARDHAT_NETWORK_NAME] as unknown as EdrNetworkUserConfig
+    const networkConfig = hre.config.networks[DEFAULT_NETWORK_NAME] as unknown as EdrNetworkUserConfig
 
     const commandArgs = constructCommandArgs({
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        forking: (hre.config.networks[HARDHAT_NETWORK_NAME] as any)?.forking,
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        forkBlockNumber: (hre.config.networks[HARDHAT_NETWORK_NAME] as any)?.forking?.blockNumber,
+        forking: networkConfig?.forking,
+        forkBlockNumber: networkConfig?.forking?.blockNumber,
         nodeCommands: networkConfig?.nodeConfig,
         adapterCommands: networkConfig?.adapterConfig,
     })

--- a/packages/hardhat-polkadot-node/src/task-actions/node.ts
+++ b/packages/hardhat-polkadot-node/src/task-actions/node.ts
@@ -1,13 +1,13 @@
 import type { TaskOverrideActionFunction } from "hardhat/types/tasks"
 
-const HARDHAT_NETWORK_NAME = "hardhat"
+import { DEFAULT_NETWORK_NAME } from "../constants.js"
 
 const nodeAction: TaskOverrideActionFunction = async (taskArguments, hre, runSuper) => {
-    const networkName = hre.globalOptions.network ?? HARDHAT_NETWORK_NAME
+    const networkName = hre.globalOptions.network ?? DEFAULT_NETWORK_NAME
     const networkConfig = hre.config.networks[networkName]
     const isPolkadot = networkConfig && "polkadot" in networkConfig && !!networkConfig.polkadot
 
-    if (!isPolkadot || networkName !== HARDHAT_NETWORK_NAME) {
+    if (!isPolkadot || networkName !== DEFAULT_NETWORK_NAME) {
         return runSuper(taskArguments)
     }
 

--- a/packages/hardhat-polkadot-node/src/task-actions/test.ts
+++ b/packages/hardhat-polkadot-node/src/task-actions/test.ts
@@ -1,3 +1,4 @@
+// TODO: Refactor to delegate server lifecycle to network hooks instead of managing it here
 import type { TaskOverrideActionFunction } from "hardhat/types/tasks"
 import type { EdrNetworkUserConfig } from "hardhat/types/config"
 

--- a/packages/hardhat-polkadot-node/src/task-actions/test.ts
+++ b/packages/hardhat-polkadot-node/src/task-actions/test.ts
@@ -10,15 +10,14 @@ import {
     ETH_RPC_ADAPTER_START_PORT,
     MAX_PORT_ATTEMPTS,
     POLKADOT_NETWORK_ACCOUNTS,
+    DEFAULT_NETWORK_NAME,
 } from "../constants.js"
 
-const HARDHAT_NETWORK_NAME = "hardhat"
-
 const testAction: TaskOverrideActionFunction = async (taskArguments, hre, runSuper) => {
-    const networkName = hre.globalOptions.network ?? HARDHAT_NETWORK_NAME
+    const networkName = hre.globalOptions.network ?? DEFAULT_NETWORK_NAME
     const networkConfig = hre.config.networks[networkName]
     const isPolkadot = networkConfig && "polkadot" in networkConfig && !!networkConfig.polkadot
-    const isHardhatNetwork = networkName === HARDHAT_NETWORK_NAME
+    const isHardhatNetwork = networkName === DEFAULT_NETWORK_NAME
 
     if (!isPolkadot) {
         return runSuper(taskArguments)
@@ -29,7 +28,7 @@ const testAction: TaskOverrideActionFunction = async (taskArguments, hre, runSup
         await hre.tasks.getTask("build").run({ quiet: true, noTests: true })
     }
 
-    const userConfig = hre.config.networks[HARDHAT_NETWORK_NAME] as unknown as EdrNetworkUserConfig
+    const userConfig = hre.config.networks[DEFAULT_NETWORK_NAME] as unknown as EdrNetworkUserConfig
     const useAnvil = userConfig?.nodeConfig?.useAnvil !== false
 
     // For remote polkadot networks, just handle factory deps and run tests
@@ -62,18 +61,15 @@ const testAction: TaskOverrideActionFunction = async (taskArguments, hre, runSup
         docker: userConfig?.docker,
         nodePath,
         adapterPath,
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        isForking: !!(networkConfig as any)?.forking?.enabled,
+        isForking: !!userConfig?.forking?.enabled,
     })
 
     const nodeCommands = Object.assign({}, userConfig?.nodeConfig, { rpcPort: nodePort })
     const adapterCommands = Object.assign({}, userConfig?.adapterConfig, { adapterPort })
 
     const commandArgs = constructCommandArgs({
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        forking: (networkConfig as any)?.forking,
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        forkBlockNumber: (networkConfig as any)?.forking?.blockNumber,
+        forking: userConfig?.forking,
+        forkBlockNumber: userConfig?.forking?.blockNumber,
         nodeCommands,
         adapterCommands,
     })
@@ -85,7 +81,7 @@ const testAction: TaskOverrideActionFunction = async (taskArguments, hre, runSup
 
         await configureNetwork(
             hre.config,
-            { name: HARDHAT_NETWORK_NAME, config: networkConfig },
+            { name: DEFAULT_NETWORK_NAME, config: networkConfig },
             useAnvil ? adapterPort : adapterPort || nodePort,
         )
 

--- a/packages/hardhat-polkadot-node/src/task-actions/test.ts
+++ b/packages/hardhat-polkadot-node/src/task-actions/test.ts
@@ -5,7 +5,6 @@ import type { EdrNetworkUserConfig } from "hardhat/types/config"
 import { createRpcServer } from "../rpc-server.js"
 import { configureNetwork, constructCommandArgs, getAvailablePort } from "../utils.js"
 import { PolkadotNodePluginError } from "../errors.js"
-import type { ForkingUserConfig } from "../types.js"
 import { handleFactoryDependencies } from "../core/factory-support.js"
 import {
     NODE_START_PORT,
@@ -58,20 +57,23 @@ const testAction: TaskOverrideActionFunction = async (taskArguments, hre, runSup
     const nodePath = userConfig?.nodeConfig?.nodeBinaryPath
     const adapterPath = userConfig?.adapterConfig?.adapterBinaryPath
 
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const forking = (userConfig as any)?.forking as { enabled?: boolean; url?: string; blockNumber?: number } | undefined
+
     const server = createRpcServer({
         useAnvil,
         docker: userConfig?.docker,
         nodePath,
         adapterPath,
-        isForking: !!userConfig?.forking?.enabled,
+        isForking: !!forking?.enabled,
     })
 
     const nodeCommands = Object.assign({}, userConfig?.nodeConfig, { rpcPort: nodePort })
     const adapterCommands = Object.assign({}, userConfig?.adapterConfig, { adapterPort })
 
     const commandArgs = constructCommandArgs({
-        forking: userConfig?.forking as ForkingUserConfig | undefined,
-        forkBlockNumber: userConfig?.forking?.blockNumber,
+        forking,
+        forkBlockNumber: forking?.blockNumber,
         nodeCommands,
         adapterCommands,
     })

--- a/packages/hardhat-polkadot-node/src/task-actions/test.ts
+++ b/packages/hardhat-polkadot-node/src/task-actions/test.ts
@@ -5,6 +5,7 @@ import type { EdrNetworkUserConfig } from "hardhat/types/config"
 import { createRpcServer } from "../rpc-server.js"
 import { configureNetwork, constructCommandArgs, getAvailablePort } from "../utils.js"
 import { PolkadotNodePluginError } from "../errors.js"
+import type { ForkingUserConfig } from "../types.js"
 import { handleFactoryDependencies } from "../core/factory-support.js"
 import {
     NODE_START_PORT,
@@ -69,7 +70,7 @@ const testAction: TaskOverrideActionFunction = async (taskArguments, hre, runSup
     const adapterCommands = Object.assign({}, userConfig?.adapterConfig, { adapterPort })
 
     const commandArgs = constructCommandArgs({
-        forking: userConfig?.forking,
+        forking: userConfig?.forking as ForkingUserConfig | undefined,
         forkBlockNumber: userConfig?.forking?.blockNumber,
         nodeCommands,
         adapterCommands,

--- a/packages/hardhat-polkadot-node/src/type-extensions.ts
+++ b/packages/hardhat-polkadot-node/src/type-extensions.ts
@@ -1,5 +1,5 @@
 import "hardhat/types/config"
-import type { TargetVM } from "./types.js"
+import type { ForkingUserConfig, TargetVM } from "./types.js"
 
 declare module "hardhat/types/config" {
     interface EdrNetworkUserConfig {
@@ -41,6 +41,7 @@ declare module "hardhat/types/config" {
          * - false: disable
          */
         docker?: boolean | string
+        forking?: ForkingUserConfig
     }
 
     interface HttpNetworkUserConfig {

--- a/packages/hardhat-polkadot-node/src/type-extensions.ts
+++ b/packages/hardhat-polkadot-node/src/type-extensions.ts
@@ -1,5 +1,5 @@
 import "hardhat/types/config"
-import type { ForkingUserConfig, TargetVM } from "./types.js"
+import type { TargetVM } from "./types.js"
 
 declare module "hardhat/types/config" {
     interface EdrNetworkUserConfig {
@@ -41,7 +41,6 @@ declare module "hardhat/types/config" {
          * - false: disable
          */
         docker?: boolean | string
-        forking?: ForkingUserConfig
     }
 
     interface HttpNetworkUserConfig {

--- a/packages/hardhat-polkadot-node/src/types.ts
+++ b/packages/hardhat-polkadot-node/src/types.ts
@@ -2,8 +2,10 @@ import type { EdrNetworkUserConfig } from "hardhat/types/config"
 import { ChopsticksService, EthRpcService, SubstrateNodeService } from "./services/index.js"
 
 /**
- * Forking config (defined locally since HardhatNetworkForkingUserConfig
- * was removed in Hardhat v3).
+ * Forking config — compatible with both HH2 and HH3.
+ * In HH3, EdrNetworkForkingUserConfig has `url: SensitiveString`
+ * (string | ConfigurationVariable). We keep `url` as `string` here
+ * and cast at the boundary where HH3's forking config is assigned.
  */
 export interface ForkingUserConfig {
     enabled?: boolean

--- a/packages/hardhat-polkadot-node/src/utils.ts
+++ b/packages/hardhat-polkadot-node/src/utils.ts
@@ -15,7 +15,6 @@ import {
     NODE_START_PORT,
     ETH_RPC_ADAPTER_START_PORT,
     POLKADOT_TEST_NODE_NETWORK_NAME,
-    RPC_ENDPOINT_PATH,
     ETH_RPC_TO_SUBSTRATE_RPC,
     DEFAULT_NETWORK_NAME,
 } from "./constants.js"
@@ -187,23 +186,6 @@ export async function configureNetwork(
     port: number,
 ) {
     const url = `${BASE_URL}:${port}`
-    const payload = {
-        jsonrpc: "2.0",
-        method: RPC_ENDPOINT_PATH,
-        params: [],
-        id: 1,
-    }
-    let _chainId = 0
-    try {
-        const response = await axios.post(url, payload)
-
-        if (response.status === 200) {
-            _chainId = parseInt(response.data.result)
-        }
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    } catch (_e: any) {
-        // If it fails, it will just try again
-    }
 
     const networkName =
         network.name === DEFAULT_NETWORK_NAME ? POLKADOT_TEST_NODE_NETWORK_NAME : network.name

--- a/packages/hardhat-polkadot-node/src/utils.ts
+++ b/packages/hardhat-polkadot-node/src/utils.ts
@@ -168,6 +168,12 @@ export function getNetworkConfig(url: string) {
     }
 }
 
+/**
+ * Mutates `config` and `network` in-place to point at the local RPC server.
+ * In-place mutation is intentional: Hardhat's resolved config object is shared
+ * across the process, and downstream code (tests, plugins) reads from the same
+ * reference. Returning a new object would leave stale URLs in the shared config.
+ */
 export async function configureNetwork(
     config: HardhatConfig,
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -199,11 +205,11 @@ export async function configureNetwork(
     const networkConfig = getNetworkConfig(url)
 
     try {
-    network.name = networkName
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    network.config = networkConfig as any
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    config.networks[networkName] = networkConfig as any
+        network.name = networkName
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        network.config = networkConfig as any
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        config.networks[networkName] = networkConfig as any
     } catch {
         // Config may be frozen in HH3's resolved config; if so, the caller
         // must handle network configuration differently.
@@ -266,10 +272,10 @@ export async function getLatestImageName(containerName: string): Promise<string>
         const imageList = imageResponse.data
 
         imageList.results.sort(
-                // eslint-disable-next-line @typescript-eslint/no-explicit-any
-                (a: any, b: any) =>
-                    new Date(b.last_updated).getTime() - new Date(a.last_updated).getTime(),
-            )
+            // eslint-disable-next-line @typescript-eslint/no-explicit-any
+            (a: any, b: any) =>
+                new Date(b.last_updated).getTime() - new Date(a.last_updated).getTime(),
+        )
 
         const latestImageName = imageList.results[0]?.name
 
@@ -279,7 +285,7 @@ export async function getLatestImageName(containerName: string): Promise<string>
             )
         }
 
-            cache.set(containerName, latestImageName)
+        cache.set(containerName, latestImageName)
 
         return latestImageName
     } else {

--- a/packages/hardhat-polkadot-node/src/utils.ts
+++ b/packages/hardhat-polkadot-node/src/utils.ts
@@ -33,7 +33,13 @@ export function constructCommandArgs(args?: CommandArguments): SplitCommands {
     const adapterCommands: string[] = []
 
     if (args?.nodeCommands?.useAnvil !== false && !args?.forking) {
+        // anvil-polkadot bundles the substrate node and eth-rpc adapter into
+        // a single process.  It uses --port (not --rpc-port) for the
+        // Ethereum JSON-RPC listener (default 8545).
         nodeCommands.push("", "--accounts", "20")
+        if (args?.adapterCommands?.adapterPort) {
+            nodeCommands.push("--port", `${args.adapterCommands.adapterPort}`)
+        }
         return {
             nodeCommands,
             adapterCommands,

--- a/packages/hardhat-polkadot-node/src/utils.ts
+++ b/packages/hardhat-polkadot-node/src/utils.ts
@@ -17,9 +17,8 @@ import {
     POLKADOT_TEST_NODE_NETWORK_NAME,
     RPC_ENDPOINT_PATH,
     ETH_RPC_TO_SUBSTRATE_RPC,
+    DEFAULT_NETWORK_NAME,
 } from "./constants.js"
-
-const HARDHAT_NETWORK_NAME = "hardhat"
 
 export const PARITYPR_DOCKER_REGISTRY = "https://registry.hub.docker.com/v2/repositories/paritypr/"
 const DOCKER_SOCKET_DEFAULT_PATH = "/var/run/docker.sock"
@@ -195,15 +194,23 @@ export async function configureNetwork(
     }
 
     const networkName =
-        network.name === HARDHAT_NETWORK_NAME ? POLKADOT_TEST_NODE_NETWORK_NAME : network.name
+        network.name === DEFAULT_NETWORK_NAME ? POLKADOT_TEST_NODE_NETWORK_NAME : network.name
 
     const networkConfig = getNetworkConfig(url)
 
+    try {
     network.name = networkName
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     network.config = networkConfig as any
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     config.networks[networkName] = networkConfig as any
+    } catch {
+        // Config may be frozen in HH3's resolved config; if so, the caller
+        // must handle network configuration differently.
+        throw new PolkadotNodePluginError(
+            `Failed to configure network "${networkName}": config object may be frozen.`,
+        )
+    }
 }
 
 export async function startServer(

--- a/packages/hardhat-polkadot-node/src/utils.ts
+++ b/packages/hardhat-polkadot-node/src/utils.ts
@@ -249,7 +249,7 @@ export async function startServer(
  * This function retrieves a list of the latest images available in the Docker registry
  * sortes them from newest to oldest, and returns the newest one, in order to be used by the DockerServer.
  */
-export async function getLatestImageName(containerName: string): Promise<string | undefined> {
+export async function getLatestImageName(containerName: string): Promise<string> {
     const cachedResult = cache.get(containerName)
     if (cachedResult) {
         return cachedResult
@@ -265,20 +265,21 @@ export async function getLatestImageName(containerName: string): Promise<string 
     if (imageResponse.status === 200) {
         const imageList = imageResponse.data
 
-        imageList.results
-            .sort(
+        imageList.results.sort(
                 // eslint-disable-next-line @typescript-eslint/no-explicit-any
                 (a: any, b: any) =>
                     new Date(b.last_updated).getTime() - new Date(a.last_updated).getTime(),
             )
-            // eslint-disable-next-line @typescript-eslint/no-explicit-any
-            .map((tag: any) => tag.name)
 
-        const latestImageName = imageList.results[0].name
+        const latestImageName = imageList.results[0]?.name
 
-        if (latestImageName) {
-            cache.set(containerName, latestImageName)
+        if (!latestImageName) {
+            throw new PolkadotNodePluginError(
+                `No image tags found for container "${containerName}"`,
+            )
         }
+
+            cache.set(containerName, latestImageName)
 
         return latestImageName
     } else {

--- a/packages/hardhat-polkadot-node/test/network-hook.test.ts
+++ b/packages/hardhat-polkadot-node/test/network-hook.test.ts
@@ -37,12 +37,11 @@ vi.mock("../src/utils.js", async (importOriginal) => {
             },
             port: 8545,
         }),
-        configureNetwork: vi.fn().mockResolvedValue(undefined),
     }
 })
 
 import networkHookHandler from "../src/hook-handlers/network.js"
-import { startServer, configureNetwork } from "../src/utils.js"
+import { startServer } from "../src/utils.js"
 
 describe("network hook handler", () => {
     beforeEach(() => {
@@ -71,10 +70,10 @@ describe("network hook handler", () => {
             const conn = makeConnection()
             const next = vi.fn().mockResolvedValue(conn)
 
-            await handler.newConnection!(ctx as any, next)
+            const result = await handler.newConnection!(ctx as any, next)
 
             expect(startServer).toHaveBeenCalled()
-            expect(configureNetwork).toHaveBeenCalled()
+            expect((result as any).localPolkadotUrl).toBe("http://127.0.0.1:8545")
         })
 
         it("skips non-polkadot networks", async () => {

--- a/packages/hardhat-polkadot-node/test/task-actions.test.ts
+++ b/packages/hardhat-polkadot-node/test/task-actions.test.ts
@@ -64,7 +64,7 @@ function makeHre(overrides: Record<string, unknown> = {}) {
         globalOptions: { network: undefined },
         config: {
             networks: {
-                hardhat: { polkadot: true, ...overrides },
+                default: { polkadot: true, ...overrides },
             },
             paths: { artifacts: "/tmp/artifacts" },
         },
@@ -81,7 +81,7 @@ describe("node task action", () => {
 
     it("delegates to runSuper for non-polkadot networks", async () => {
         const hre = makeHre()
-        hre.config.networks.hardhat = {} as any
+        hre.config.networks.default = {} as any
         const runSuper = vi.fn().mockResolvedValue("super")
 
         const result = await nodeAction({}, hre as any, runSuper)
@@ -130,7 +130,7 @@ describe("test task action", () => {
 
     it("delegates to runSuper for non-polkadot networks", async () => {
         const hre = makeHre()
-        hre.config.networks.hardhat = {} as any
+        hre.config.networks.default = {} as any
         const runSuper = vi.fn().mockResolvedValue(0)
 
         await testAction({ noCompile: true }, hre as any, runSuper)

--- a/packages/hardhat-polkadot-resolc/src/download.ts
+++ b/packages/hardhat-polkadot-resolc/src/download.ts
@@ -74,14 +74,20 @@ export async function download(
                     )
 
                     const checksumLines = (checksumResponse.data as string).split("\n")
+                    // Checksum files use two formats:
+                    //   text mode:   "hash  filename"  (two spaces)
+                    //   binary mode:  "hash *filename"  (space + asterisk)
                     const matchingLine = checksumLines.find((line: string) => {
-                        const parts = line.trim().split(/\s+/)
-                        return parts.length >= 2 && parts[parts.length - 1] === name
+                        const trimmed = line.trim()
+                        // Strip the hash prefix, then match the filename
+                        // accounting for both " filename" and " *filename"
+                        const filename = trimmed.replace(/^[0-9a-fA-F]+\s+\*?/, "")
+                        return filename === name
                     })
                     if (!matchingLine) {
                         throw new Error(`Checksum not found for ${name} in v${version}`)
                     }
-                    sha256 = matchingLine.trim().split(" ")[0]
+                    sha256 = matchingLine.trim().split(/\s/)[0]
                 } else {
                     sha256 = asset.digest.slice(7)
                 }

--- a/packages/hardhat-polkadot-resolc/src/download.ts
+++ b/packages/hardhat-polkadot-resolc/src/download.ts
@@ -74,7 +74,10 @@ export async function download(
                     )
 
                     const checksumLines = (checksumResponse.data as string).split("\n")
-                    const matchingLine = checksumLines.find((line: string) => line.includes(name))
+                    const matchingLine = checksumLines.find((line: string) => {
+                        const parts = line.trim().split(/\s+/)
+                        return parts.length >= 2 && parts[parts.length - 1] === name
+                    })
                     if (!matchingLine) {
                         throw new Error(`Checksum not found for ${name} in v${version}`)
                     }

--- a/packages/hardhat-polkadot-resolc/src/downloader.ts
+++ b/packages/hardhat-polkadot-resolc/src/downloader.ts
@@ -162,6 +162,7 @@ export class ResolcCompilerDownloader implements IResolcCompilerDownloader {
         )
 
         if (await fsExtra.pathExists(this._getCompilerDoesntWorkFile(build))) {
+            log("Native resolc binary for %s is marked as non-working, skipping", version)
             return undefined
         }
 

--- a/packages/hardhat-polkadot-resolc/src/hook-handlers/solidity.ts
+++ b/packages/hardhat-polkadot-resolc/src/hook-handlers/solidity.ts
@@ -82,24 +82,31 @@ async function getResolcBuild(resolcConfig: ResolcConfig): Promise<ResolcBuild> 
 function normalizeCompilerOutput(compOut: any): CompilerOutput {
     if (!compOut.contracts) return compOut
 
-    for (const file of Object.keys(compOut.contracts)) {
-        for (const contract of Object.keys(compOut.contracts[file])) {
-            const bytecode = compOut.contracts[file][contract].evm?.bytecode
-                ? compOut.contracts[file][contract].evm.bytecode.object
-                : ""
-            if (compOut.contracts[file][contract].evm) {
-                compOut.contracts[file][contract].evm.bytecode = {
-                    functionDebugData: {},
-                    generatedSources: [],
-                    linkReferences: {},
-                    object: bytecode,
-                    opcodes: "",
-                    sourceMap: "",
+    const result = { ...compOut, contracts: { ...compOut.contracts } }
+    for (const file of Object.keys(result.contracts)) {
+        result.contracts[file] = { ...result.contracts[file] }
+        for (const contract of Object.keys(result.contracts[file])) {
+            const original = result.contracts[file][contract]
+            const bytecode = original.evm?.bytecode?.object ?? ""
+            if (original.evm) {
+                result.contracts[file][contract] = {
+                    ...original,
+                    evm: {
+                        ...original.evm,
+                        bytecode: {
+                            functionDebugData: {},
+                            generatedSources: [],
+                            linkReferences: {},
+                            object: bytecode,
+                            opcodes: "",
+                            sourceMap: "",
+                        },
+                    },
                 }
             }
         }
     }
-    return compOut
+    return result
 }
 
 // SolidityHooks is augmented onto HardhatHooks by the solidity plugin

--- a/packages/hardhat-polkadot/src/cli/project-creation.ts
+++ b/packages/hardhat-polkadot/src/cli/project-creation.ts
@@ -494,12 +494,12 @@ async function installDependencies(packageManager: string, args: string[]): Prom
                 return
             }
 
-            reject(false)
+            reject(new Error(`Process ${packageManager} exited with code ${status}`))
         })
 
-        childProcess.once("error", (_status) => {
+        childProcess.once("error", (err) => {
             childProcess.removeAllListeners("close")
-            reject(false)
+            reject(new Error(`Failed to spawn ${packageManager}: ${err.message}`))
         })
     })
 }


### PR DESCRIPTION
#### HH3 Compatibility
- Default network renamed from "hardhat" to "default", centralized as a constant
- Added resolveUserConfig hook to re-apply polkadot, nodeConfig, adapterConfig, docker, and forking fields that HH3's network resolution strips
- Removed redundant forking type augmentation (HH3 already provides it), eliminated as any casts
- Fixed network hook: removed broken post-next() config mutation that has no effect in HH3's architecture

#### anvil-polkadot Integration

- Readiness check now uses eth_chainId for anvil (Ethereum RPC server) instead of state_getRuntimeVersion (Substrate RPC it doesn't implement)
- Custom port now forwarded to anvil via --port flag — previously ignored, causing silent port mismatches

#### Bug Fixes

- Chopsticks: wait for spawn event instead of resolving immediately
- Container cleanup: replaced unsafe signal handlers with process.once("SIGINT"|"SIGTERM") + graceful stop()
- Docker inspect: only swallow 404, propagate real errors
- getLatestImageName: removed dead .map(), throw instead of returning undefined
- normalizeCompilerOutput: clone before mutating compiler output
- project-creation: reject(new Error(...)) instead of reject(false)
- Checksum matching: exact filename match instead of line.includes(name)
- Added debug logging for non-working resolc binaries and clean service exits