### PR TITLE
fix: update network hooks

### DIFF
--- a/packages/hardhat-polkadot-node/src/hook-handlers/network.ts
+++ b/packages/hardhat-polkadot-node/src/hook-handlers/network.ts
@@ -1,6 +1,9 @@
 import type { HookContext } from "hardhat/types/hooks"
 import type { NetworkConnection, ChainType } from "hardhat/types/network"
 import type { EdrNetworkUserConfig } from "hardhat/types/config"
+import type { JsonRpcRequest, JsonRpcResponse } from "hardhat/types/providers"
+
+import axios from "axios"
 
 import { startServer } from "../utils.js"
 import { BASE_URL } from "../constants.js"
@@ -22,38 +25,70 @@ interface NetworkHooks {
             nextNetworkConnection: NetworkConnection<ChainTypeT>,
         ) => Promise<void>,
     ) => Promise<void>
+    onRequest: <ChainTypeT extends ChainType | string>(
+        context: HookContext,
+        networkConnection: NetworkConnection<ChainTypeT>,
+        jsonRpcRequest: JsonRpcRequest,
+        next: (
+            nextContext: HookContext,
+            nextNetworkConnection: NetworkConnection<ChainTypeT>,
+            nextJsonRpcRequest: JsonRpcRequest,
+        ) => Promise<JsonRpcResponse>,
+    ) => Promise<JsonRpcResponse>
 }
 
-// Track active servers per connection so we can clean up on close
-const activeServers = new Map<number, RpcServer>()
+// Per-network server state
+interface PolkadotServer {
+    server: RpcServer
+    url: string
+    refCount: number
+}
 
-const networkHookHandler: () => Promise<Partial<NetworkHooks>> = async () => ({
-    newConnection: async (context, next) => {
-        const connection = await next(context)
+const polkadotServers = new Map<string, PolkadotServer>()
+const pendingStarts = new Map<string, Promise<PolkadotServer>>()
+// Map connection IDs to their network name for cleanup
+const connectionNetworks = new Map<number, string>()
 
-        const networkConfig = connection.networkConfig
-        if (!("polkadot" in networkConfig) || !networkConfig.polkadot) {
-            return connection
-        }
+function isPolkadotNetwork(
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    network: Record<string, any> | undefined,
+): boolean {
+    if (!network || !("polkadot" in network) || !network.polkadot) return false
+    const polkadot = network.polkadot
+    if (typeof polkadot !== "boolean" && polkadot?.target === "evm") return false
+    return true
+}
 
-        // Skip if targeting EVM
-        const polkadot = networkConfig.polkadot
-        if (typeof polkadot !== "boolean" && polkadot?.target === "evm") {
-            return connection
-        }
+async function ensureServerStarted(
+    networkName: string,
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    userNetworkConfig: Record<string, any>,
+): Promise<PolkadotServer> {
+    // Already running
+    const existing = polkadotServers.get(networkName)
+    if (existing) {
+        existing.refCount++
+        return existing
+    }
 
-        // Get the user config for this network to read nodeConfig/adapterConfig
-        const networkName = connection.networkName
-        const userNetworkConfig = context.userConfig.networks?.[networkName]
-        if (!userNetworkConfig) return connection
+    // Another connection is already starting this server — wait for it
+    const pending = pendingStarts.get(networkName)
+    if (pending) {
+        const result = await pending
+        result.refCount++
+        return result
+    }
 
-        // Cast to EdrNetworkUserConfig to access our augmented fields
+    // Start the server
+    const startPromise = (async (): Promise<PolkadotServer> => {
         const edrConfig = userNetworkConfig as EdrNetworkUserConfig
         const nodeConfig = edrConfig.nodeConfig
         const adapterConfig = edrConfig.adapterConfig
         const docker = edrConfig.docker
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        const forking = (edrConfig as any).forking as { enabled?: boolean; url?: string } | undefined
+        const forking = (edrConfig as any).forking as
+            | { enabled?: boolean; url?: string }
+            | undefined
 
         const { commandArgs, server, port } = await startServer(
             {
@@ -69,31 +104,82 @@ const networkHookHandler: () => Promise<Partial<NetworkHooks>> = async () => ({
         await server.listen(commandArgs.nodeCommands, commandArgs.adapterCommands, false)
         await server.services().substrateNodeService?.waitForNodeToBeReady()
 
-        // Track the server for cleanup
-        activeServers.set(connection.id, server)
+        const polkadotServer: PolkadotServer = {
+            server,
+            url: `${BASE_URL}:${port}`,
+            refCount: 1,
+        }
+        polkadotServers.set(networkName, polkadotServer)
+        return polkadotServer
+    })()
 
-        // Store the local URL on the resolved config so downstream code (e.g.
-        // factory-deps) can discover it.  The connection's own provider was
-        // already created by `next()`, so this does NOT redirect the provider;
-        // the task-actions path (test.ts) remains the primary integration
-        // point where the URL is wired up before the provider is created.
-        // TODO: To fully integrate with HH3's connection model, polkadot
-        // networks should resolve as type:"http" pointing at the local server
-        // URL, so the provider is created with the correct endpoint. This
-        // requires starting the server in resolveUserConfig or using the
-        // onRequest hook to proxy requests.
-        const localUrl = `${BASE_URL}:${port}`
+    pendingStarts.set(networkName, startPromise)
+    try {
+        return await startPromise
+    } finally {
+        pendingStarts.delete(networkName)
+    }
+}
+
+const networkHookHandler: () => Promise<Partial<NetworkHooks>> = async () => ({
+    newConnection: async (context, next) => {
+        // Identify which polkadot networks need servers started.
+        // We do this before next() so the server is ready, but the provider
+        // is redirected via the onRequest hook (not by mutating config).
+        const userNetworks = context.userConfig.networks ?? {}
+        for (const [name, network] of Object.entries(userNetworks)) {
+            // eslint-disable-next-line @typescript-eslint/no-explicit-any
+            if (!isPolkadotNetwork(network as any)) continue
+            if (polkadotServers.has(name) || pendingStarts.has(name)) continue
+            // eslint-disable-next-line @typescript-eslint/no-explicit-any
+            await ensureServerStarted(name, network as any)
+            // Decrement refCount since ensureServerStarted incremented it,
+            // but this pre-start isn't tied to a connection yet
+            polkadotServers.get(name)!.refCount--
+        }
+
+        const connection = await next(context)
+
+        const networkName = connection.networkName
+        const userNetworkConfig = userNetworks[networkName]
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        ;(connection as any).localPolkadotUrl = localUrl
+        if (userNetworkConfig && isPolkadotNetwork(userNetworkConfig as any)) {
+            // eslint-disable-next-line @typescript-eslint/no-explicit-any
+            const ps = await ensureServerStarted(networkName, userNetworkConfig as any)
+            connectionNetworks.set(connection.id, networkName)
+            // Store URL on connection for downstream code (e.g. factory-deps)
+            // eslint-disable-next-line @typescript-eslint/no-explicit-any
+            ;(connection as any).localPolkadotUrl = ps.url
+        }
 
         return connection
     },
 
+    onRequest: async (context, networkConnection, jsonRpcRequest, next) => {
+        const networkName = networkConnection.networkName
+        const ps = polkadotServers.get(networkName)
+        if (!ps) {
+            // Not a polkadot network — pass through to EDR/HTTP
+            return next(context, networkConnection, jsonRpcRequest)
+        }
+
+        // Proxy the JSON-RPC request to the local polkadot server
+        const response = await axios.post(ps.url, jsonRpcRequest)
+        return response.data as JsonRpcResponse
+    },
+
     closeConnection: async (context, networkConnection, next) => {
-        const server = activeServers.get(networkConnection.id)
-        if (server) {
-            await server.stop()
-            activeServers.delete(networkConnection.id)
+        const networkName = connectionNetworks.get(networkConnection.id)
+        if (networkName) {
+            connectionNetworks.delete(networkConnection.id)
+            const ps = polkadotServers.get(networkName)
+            if (ps) {
+                ps.refCount--
+                if (ps.refCount <= 0) {
+                    await ps.server.stop()
+                    polkadotServers.delete(networkName)
+                }
+            }
         }
 
         return next(context, networkConnection)

--- a/packages/hardhat-polkadot-node/src/task-actions/test.ts
+++ b/packages/hardhat-polkadot-node/src/task-actions/test.ts
@@ -1,4 +1,3 @@
-// TODO: Refactor to delegate server lifecycle to network hooks instead of managing it here
 import type { TaskOverrideActionFunction } from "hardhat/types/tasks"
 import type { EdrNetworkUserConfig } from "hardhat/types/config"
 

--- a/packages/hardhat-polkadot-node/src/types.ts
+++ b/packages/hardhat-polkadot-node/src/types.ts
@@ -2,8 +2,8 @@ import type { EdrNetworkUserConfig } from "hardhat/types/config"
 import { ChopsticksService, EthRpcService, SubstrateNodeService } from "./services/index.js"
 
 /**
- * Forking config — compatible with both HH2 and HH3.
- * In HH3, EdrNetworkForkingUserConfig has `url: SensitiveString`
+ * Forking config for internal use.
+ * HH3's EdrNetworkForkingUserConfig has `url: SensitiveString`
  * (string | ConfigurationVariable). We keep `url` as `string` here
  * and cast at the boundary where HH3's forking config is assigned.
  */

--- a/packages/hardhat-polkadot-node/src/utils.ts
+++ b/packages/hardhat-polkadot-node/src/utils.ts
@@ -85,6 +85,7 @@ export function constructCommandArgs(args?: CommandArguments): SplitCommands {
         }
 
         if (args.nodeCommands?.nodeBinaryPath && args.nodeCommands?.consensus) {
+            // revive-dev-node accepts: "instant-seal", "manual-seal-{N}", "none"
             if (args.nodeCommands.consensus.seal === "Manual") {
                 const period: number = parseInt(`${args.nodeCommands.consensus.period}`, 10)
                 const manualSealTag: string = Number.isNaN(period)
@@ -92,10 +93,10 @@ export function constructCommandArgs(args?: CommandArguments): SplitCommands {
                     : "manual-seal-" + (period || 50)
 
                 nodeCommands.push(`--consensus=${manualSealTag}`)
+            } else if (args.nodeCommands.consensus.seal === "Instant") {
+                nodeCommands.push(`--consensus=instant-seal`)
             } else {
-                nodeCommands.push(
-                    `--consensus=${(args.nodeCommands.consensus.seal || "None").toLowerCase()}`,
-                )
+                nodeCommands.push(`--consensus=none`)
             }
         }
 

--- a/packages/hardhat-polkadot-node/test/network-hook.test.ts
+++ b/packages/hardhat-polkadot-node/test/network-hook.test.ts
@@ -20,6 +20,12 @@ vi.mock("../src/services/service.js", async () => {
     return { Service }
 })
 
+const { mockListen, mockStop, mockWaitNode } = vi.hoisted(() => ({
+    mockListen: vi.fn().mockResolvedValue(undefined),
+    mockStop: vi.fn().mockResolvedValue(undefined),
+    mockWaitNode: vi.fn().mockResolvedValue(undefined),
+}))
+
 vi.mock("../src/utils.js", async (importOriginal) => {
     const actual = await importOriginal<typeof import("../src/utils.js")>()
     return {
@@ -27,10 +33,10 @@ vi.mock("../src/utils.js", async (importOriginal) => {
         startServer: vi.fn().mockResolvedValue({
             commandArgs: { nodeCommands: [], adapterCommands: [] },
             server: {
-                listen: vi.fn().mockResolvedValue(undefined),
-                stop: vi.fn().mockResolvedValue(undefined),
+                listen: mockListen,
+                stop: mockStop,
                 services: () => ({
-                    substrateNodeService: { waitForNodeToBeReady: vi.fn().mockResolvedValue(undefined) },
+                    substrateNodeService: { waitForNodeToBeReady: mockWaitNode },
                     ethRpcService: null,
                     chopsticksService: null,
                 }),
@@ -40,10 +46,22 @@ vi.mock("../src/utils.js", async (importOriginal) => {
     }
 })
 
+vi.mock("axios", () => ({
+    default: {
+        post: vi.fn().mockResolvedValue({
+            data: { jsonrpc: "2.0", id: 1, result: "0x1" },
+        }),
+    },
+}))
+
 import networkHookHandler from "../src/hook-handlers/network.js"
 import { startServer } from "../src/utils.js"
+import axios from "axios"
 
 describe("network hook handler", () => {
+    // Each test gets a fresh handler to avoid shared module-level state
+    // leaking between tests (the maps are per-module, but each handler
+    // invocation works against them)
     beforeEach(() => {
         vi.clearAllMocks()
     })
@@ -57,14 +75,14 @@ describe("network hook handler", () => {
 
     function makeConnection(overrides: Record<string, unknown> = {}) {
         return {
-            id: 1,
+            id: Math.floor(Math.random() * 100000),
             networkName: "hardhat",
             networkConfig: { polkadot: true, ...overrides },
         }
     }
 
     describe("newConnection", () => {
-        it("starts server for polkadot network", async () => {
+        it("starts server for polkadot network and sets localPolkadotUrl", async () => {
             const handler = await networkHookHandler()
             const ctx = makeContext({ polkadot: true, nodeConfig: { useAnvil: true } })
             const conn = makeConnection()
@@ -73,6 +91,8 @@ describe("network hook handler", () => {
             const result = await handler.newConnection!(ctx as any, next)
 
             expect(startServer).toHaveBeenCalled()
+            expect(mockListen).toHaveBeenCalled()
+            expect(mockWaitNode).toHaveBeenCalled()
             expect((result as any).localPolkadotUrl).toBe("http://127.0.0.1:8545")
         })
 
@@ -100,11 +120,74 @@ describe("network hook handler", () => {
         })
     })
 
+    describe("onRequest", () => {
+        it("proxies requests to the local polkadot server", async () => {
+            const handler = await networkHookHandler()
+            const ctx = makeContext({ polkadot: true, nodeConfig: { useAnvil: true } })
+            const conn = makeConnection()
+            const connNext = vi.fn().mockResolvedValue(conn)
+
+            // First establish the connection so the server is started
+            await handler.newConnection!(ctx as any, connNext)
+
+            // Now test onRequest
+            const request = { jsonrpc: "2.0" as const, id: 1, method: "eth_chainId" }
+            const requestNext = vi.fn()
+
+            const result = await handler.onRequest!(ctx as any, conn as any, request, requestNext)
+
+            expect(axios.post).toHaveBeenCalledWith("http://127.0.0.1:8545", request)
+            expect(requestNext).not.toHaveBeenCalled()
+            expect(result).toEqual({ jsonrpc: "2.0", id: 1, result: "0x1" })
+        })
+
+        it("passes through for non-polkadot networks", async () => {
+            const handler = await networkHookHandler()
+            const ctx = makeContext({})
+            const conn = { id: 500, networkName: "mainnet", networkConfig: {} }
+            const request = { jsonrpc: "2.0" as const, id: 1, method: "eth_chainId" }
+            const mockResponse = { jsonrpc: "2.0", id: 1, result: "0x1" }
+            const requestNext = vi.fn().mockResolvedValue(mockResponse)
+
+            const result = await handler.onRequest!(ctx as any, conn as any, request, requestNext)
+
+            expect(requestNext).toHaveBeenCalled()
+            expect(axios.post).not.toHaveBeenCalled()
+            expect(result).toEqual(mockResponse)
+        })
+    })
+
     describe("closeConnection", () => {
+        it("stops server when last connection closes", async () => {
+            // Use a unique network name to avoid interference from other tests
+            const networkName = `polkadot-close-${Date.now()}`
+            const handler = await networkHookHandler()
+            const ctx = {
+                config: { networks: {} },
+                userConfig: { networks: { [networkName]: { polkadot: true, nodeConfig: { useAnvil: true } } } },
+            }
+            const conn = {
+                id: Math.floor(Math.random() * 100000),
+                networkName,
+                networkConfig: { polkadot: true },
+            }
+            const connNext = vi.fn().mockResolvedValue(conn)
+
+            // Open connection (starts server)
+            await handler.newConnection!(ctx as any, connNext)
+
+            // Close connection (should stop server since refCount drops to 0)
+            const closeNext = vi.fn().mockResolvedValue(undefined)
+            await handler.closeConnection!({} as any, conn as any, closeNext)
+
+            expect(mockStop).toHaveBeenCalled()
+            expect(closeNext).toHaveBeenCalled()
+        })
+
         it("calls next for connections without tracked servers", async () => {
             const handler = await networkHookHandler()
             const next = vi.fn().mockResolvedValue(undefined)
-            const conn = { id: 999, networkName: "hardhat", networkConfig: {} }
+            const conn = { id: 999, networkName: "unknown", networkConfig: {} }
 
             await handler.closeConnection!({} as any, conn as any, next)
 

--- a/packages/hardhat-polkadot-node/test/utils.test.ts
+++ b/packages/hardhat-polkadot-node/test/utils.test.ts
@@ -143,7 +143,7 @@ describe("constructCommandArgs", () => {
                 consensus: { seal: "Manual", period: "invalid" },
             },
         })
-        expect(result.nodeCommands).toContain("--consensus=manual-seal")
+        expect(result.nodeCommands).toContain("--consensus=manual-seal-50")
     })
 
     it("adds dev and pruning flags when dev mode enabled", () => {

--- a/packages/hardhat-polkadot-node/test/utils.test.ts
+++ b/packages/hardhat-polkadot-node/test/utils.test.ts
@@ -143,7 +143,7 @@ describe("constructCommandArgs", () => {
                 consensus: { seal: "Manual", period: "invalid" },
             },
         })
-        expect(result.nodeCommands).toContain("--consensus=manual-seal-50")
+        expect(result.nodeCommands).toContain("--consensus=manual-seal")
     })
 
     it("adds dev and pruning flags when dev mode enabled", () => {


### PR DESCRIPTION
- Added an `onRequest` hook that intercepts JSON-RPC calls for polkadot networks and proxies them to the local server, bypassing EDR. 
- `newConnection` now starts servers before `next()` , so the `onRequest` proxy is ready when the first request arrives.
- `closeConnection` reference-counts connections per network and stops the server when the last connection closes.
- Imported `JsonRpcRequest`/`JsonRpcResponse` from `hardhat/types/providers` instead of defining locally.
- Fixed `consensus` parsing