### PR TITLE
fix: use latest version of resolc

### DIFF
--- a/packages/hardhat-polkadot-resolc/src/constants.ts
+++ b/packages/hardhat-polkadot-resolc/src/constants.ts
@@ -7,14 +7,16 @@ export const DEFAULT_TIMEOUT_MILISECONDS = 30000
 export const COMPILER_REPOSITORY_URL = "https://github.com/paritytech/revive/releases/download/"
 export const COMPILER_REPOSITORY_API_URL = "https://api.github.com/repos/paritytech/revive/releases"
 
+export const RESOLC_VERSION_LATEST = "latest"
+
 export const defaultNpmResolcConfig: ResolcConfig = {
-    version: "0.5.0",
+    version: RESOLC_VERSION_LATEST,
     compilerSource: "npm",
     settings: {},
 }
 
 export const defaultBinaryResolcConfig: ResolcConfig = {
-    version: "0.5.0",
+    version: RESOLC_VERSION_LATEST,
     compilerSource: "binary",
     settings: {
         optimizer: {

--- a/packages/hardhat-polkadot-resolc/src/downloader.ts
+++ b/packages/hardhat-polkadot-resolc/src/downloader.ts
@@ -199,6 +199,27 @@ export class ResolcCompilerDownloader implements IResolcCompilerDownloader {
         return age > this._compilerListCachePeriodMs
     }
 
+    public async getLatestVersion(): Promise<string> {
+        if (await this._shouldDownloadCompilerList()) {
+            await this._downloadCompilerList()
+        }
+
+        const listPath = this._getCompilerListPath()
+        if (!(await fsExtra.pathExists(listPath))) {
+            throw new ResolcPluginError("Could not fetch resolc compiler list to determine latest version")
+        }
+
+        const list = await this._readCompilerList(listPath)
+        // The builds list is populated from non-prerelease GitHub releases
+        // that have the matching platform binary. Pick the highest version.
+        if (list.builds.length === 0) {
+            throw new ResolcPluginError("No resolc compiler builds found in the release list")
+        }
+
+        // Builds are in insertion order from the releases API (newest first)
+        return list.builds[0].version
+    }
+
     private async _getCompilerBuild(version: string): Promise<CompilerBuild | undefined> {
         const listPath = this._getCompilerListPath()
         if (!(await fsExtra.pathExists(listPath))) {

--- a/packages/hardhat-polkadot-resolc/src/hook-handlers/solidity.ts
+++ b/packages/hardhat-polkadot-resolc/src/hook-handlers/solidity.ts
@@ -9,6 +9,7 @@ import { getCacheDir } from "@nomicfoundation/hardhat-utils/global-dir"
 import { compile } from "../compile/index.js"
 import { ResolcCompilerDownloader } from "../downloader.js"
 import { ResolcPluginError } from "../errors.js"
+import { RESOLC_VERSION_LATEST } from "../constants.js"
 import { getVersionComponents, pluralize } from "../utils.js"
 import type { CompilerPlatform, ResolcBuild, ResolcConfig } from "../types.js"
 
@@ -19,7 +20,18 @@ const logDebug = debug("hardhat:core:tasks:compile")
  * Falls back to WASM if the native binary doesn't work.
  */
 async function getResolcBuild(resolcConfig: ResolcConfig): Promise<ResolcBuild> {
-    const resolcVersion = resolcConfig.version
+    let resolcVersion = resolcConfig.version
+
+    // Resolve "latest" to an actual version number
+    if (resolcVersion === RESOLC_VERSION_LATEST) {
+        const nativePlatform = ResolcCompilerDownloader.getCompilerPlatform()
+        const compilersCache = await getCacheDir()
+        const downloader = ResolcCompilerDownloader.getConcurrencySafeDownloader(
+            nativePlatform,
+            compilersCache,
+        )
+        resolcVersion = await downloader.getLatestVersion()
+    }
     const compilersCache = await getCacheDir()
 
     const downloadAndGet = async (
@@ -131,10 +143,10 @@ interface SolidityHooks {
 }
 
 const solidityHookHandler: () => Promise<Partial<SolidityHooks>> = async () => ({
-    invokeSolc: async (context, _compiler, solcInput, solcConfig, next) => {
+    invokeSolc: async (context, compiler, solcInput, solcConfig, next) => {
         const resolcConfig: ResolcConfig | undefined = context.config.resolc
         if (!resolcConfig) {
-            return next(context, _compiler, solcInput, solcConfig)
+            return next(context, compiler, solcInput, solcConfig)
         }
 
         // Validate solidity version
@@ -156,13 +168,25 @@ const solidityHookHandler: () => Promise<Partial<SolidityHooks>> = async () => (
             ...resolcConfig,
             settings: {
                 resolcPath: resolcBuild.resolcPath,
-                solcPath: solcConfig.path,
+                solcPath: compiler.compilerPath,
                 ...resolcConfig.settings,
             },
         }
 
         const compOut = await compile(config, solcInput)
         const output = normalizeCompilerOutput(compOut)
+
+        // Embed resolc metadata in the output so it appears in build-info
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        ;(output as any).resolc = {
+            version: resolcBuild.version,
+            longVersion: resolcBuild.longVersion,
+            isWasm: resolcBuild.isJs,
+            resolcPath: resolcBuild.resolcPath,
+            solcVersion: solcConfig.version,
+            solcPath: compiler.compilerPath,
+            optimizer: resolcConfig.settings?.optimizer ?? null,
+        }
 
         if (count > 0) {
             console.info(

--- a/packages/hardhat-polkadot-resolc/test/constants.test.ts
+++ b/packages/hardhat-polkadot-resolc/test/constants.test.ts
@@ -33,8 +33,8 @@ describe("defaultNpmResolcConfig", () => {
         expect(defaultNpmResolcConfig.compilerSource).toBe("npm")
     })
 
-    it("has a version", () => {
-        expect(defaultNpmResolcConfig.version).toMatch(/^\d+\.\d+\.\d+$/)
+    it("has a version defaulting to latest", () => {
+        expect(defaultNpmResolcConfig.version).toBe("latest")
     })
 
     it("has empty settings", () => {
@@ -47,8 +47,8 @@ describe("defaultBinaryResolcConfig", () => {
         expect(defaultBinaryResolcConfig.compilerSource).toBe("binary")
     })
 
-    it("has a version", () => {
-        expect(defaultBinaryResolcConfig.version).toMatch(/^\d+\.\d+\.\d+$/)
+    it("has a version defaulting to latest", () => {
+        expect(defaultBinaryResolcConfig.version).toBe("latest")
     })
 
     it("enables optimizer by default", () => {


### PR DESCRIPTION
`resolc` version to default to used to be hardcoded. This changes this in order to work with "latest" if no version is specified.