### PR TITLE
fix: have npx hardhat node work without specifying polkadot

### DIFF
--- a/packages/hardhat-polkadot-node/src/core/factory-support.ts
+++ b/packages/hardhat-polkadot-node/src/core/factory-support.ts
@@ -1,6 +1,6 @@
 import { Wallet, JsonRpcProvider } from "ethers"
 import fs from "fs"
-import { glob } from "fast-glob"
+import fg from "fast-glob"
 import chalk from "chalk"
 import type {
     EdrNetworkConfig,
@@ -35,7 +35,7 @@ export async function handleFactoryDependencies(
     useAnvil?: boolean,
 ) {
     // get last build info file
-    const files = await glob(`${pathToArtifacts}/build-info/*.json`)
+    const files = await fg.glob(`${pathToArtifacts}/build-info/*.json`)
     if (files.length === 0) return
     files.sort((a, b) => fs.statSync(b).mtimeMs - fs.statSync(a).mtimeMs)
     const lastBuildInfo = JSON.parse(fs.readFileSync(files[0], "utf8"))

--- a/packages/hardhat-polkadot-node/src/index.ts
+++ b/packages/hardhat-polkadot-node/src/index.ts
@@ -1,4 +1,5 @@
 import type { HardhatPlugin } from "hardhat/types/plugins"
+import { ArgumentType } from "hardhat/types/arguments"
 import { overrideTask, task } from "hardhat/config"
 
 import "./type-extensions.js"
@@ -30,6 +31,18 @@ const hardhatPolkadotNodePlugin: HardhatPlugin = {
             .build(),
 
         task("node-polkadot", "Start a Polkadot JSON-RPC server")
+            .addOption({
+                name: "hostname",
+                description: "The host to bind to for new connections",
+                type: ArgumentType.STRING_WITHOUT_DEFAULT,
+                defaultValue: undefined,
+            })
+            .addOption({
+                name: "port",
+                description: "The port on which to listen for new connections",
+                type: ArgumentType.INT,
+                defaultValue: 8545,
+            })
             .setAction(async () => import("./task-actions/node-polkadot.js"))
             .build(),
     ],

--- a/packages/hardhat-polkadot-node/src/task-actions/node.ts
+++ b/packages/hardhat-polkadot-node/src/task-actions/node.ts
@@ -11,7 +11,10 @@ const nodeAction: TaskOverrideActionFunction = async (taskArguments, hre, runSup
         return runSuper(taskArguments)
     }
 
-    return hre.tasks.getTask("node-polkadot").run(taskArguments)
+    return hre.tasks.getTask("node-polkadot").run({
+        hostname: taskArguments.hostname,
+        port: taskArguments.port,
+    })
 }
 
 export default nodeAction


### PR DESCRIPTION
With the new version, hardhat has added cli params to the `npx hardhat node` command, that need to be covered by our override in order to work.

It also fixes a small bug for factory uploads.