### PR TITLE
fix: update network name from hardhat to default

### DIFF
--- a/examples/all-polkavm-networks/hardhat.config.ts
+++ b/examples/all-polkavm-networks/hardhat.config.ts
@@ -8,7 +8,7 @@ export default defineConfig({
     solidity: "0.8.28",
     networks: {
         // npx hardhat node
-        hardhat: {
+        default: {
             polkadot: true,
             nodeConfig: {
                 useAnvil: true,

--- a/examples/anvil.config.ts
+++ b/examples/anvil.config.ts
@@ -5,7 +5,7 @@ export default defineConfig({
     plugins: [polkadot],
     solidity: "0.8.28",
     networks: {
-        hardhat: {
+        default: {
             polkadot: {
                 target: "evm",
             },

--- a/examples/forking/hardhat.config.ts
+++ b/examples/forking/hardhat.config.ts
@@ -6,7 +6,7 @@ export default defineConfig({
     solidity: "0.8.28",
     networks: {
         // npx hardhat node
-        hardhat: {
+        default: {
             polkadot: {
                 target: "evm",
             },

--- a/examples/localNode.config.ts
+++ b/examples/localNode.config.ts
@@ -5,7 +5,7 @@ export default defineConfig({
     plugins: [polkadot],
     solidity: "0.8.28",
     networks: {
-        hardhat: {
+        default: {
             polkadot: {
                 target: "evm",
             },

--- a/examples/npm.config.ts
+++ b/examples/npm.config.ts
@@ -5,7 +5,7 @@ export default defineConfig({
     plugins: [polkadot],
     solidity: "0.8.28",
     networks: {
-        hardhat: {
+        default: {
             polkadot: true,
         },
     },

--- a/examples/using-docker/hardhat.config.ts
+++ b/examples/using-docker/hardhat.config.ts
@@ -5,7 +5,7 @@ export default defineConfig({
     plugins: [polkadot],
     solidity: "0.8.28",
     networks: {
-        hardhat: {
+        default: {
             polkadot: true,
             // see https://github.com/paritytech/hardhat-polkadot/blob/500cba0310fad38cf01cc7b11cb2e4043bd71482/packages/hardhat-polkadot-node/src/type-extensions.ts#L33
             docker: true,

--- a/examples/with-evm-networks/hardhat.config.ts
+++ b/examples/with-evm-networks/hardhat.config.ts
@@ -5,7 +5,7 @@ export default defineConfig({
     plugins: [polkadot],
     solidity: "0.8.28",
     networks: {
-        hardhat: {
+        default: {
             allowUnlimitedContractSize: false,
             chainId: 31337,
         },

--- a/packages/hardhat-polkadot-migrator/src/index.ts
+++ b/packages/hardhat-polkadot-migrator/src/index.ts
@@ -13,7 +13,7 @@ import {
 const MODULE = "@parity/hardhat-polkadot"
 const PATCH = {
     networks: {
-        hardhat: {
+        default: {
             polkadot: true,
             nodeConfig: {
                 nodeBinaryPath: "./bin/anvil-polkadot",

--- a/packages/hardhat-polkadot/sample-projects/javascript-esm/hardhat.config.cjs
+++ b/packages/hardhat-polkadot/sample-projects/javascript-esm/hardhat.config.cjs
@@ -6,7 +6,7 @@ module.exports = defineConfig({
   plugins: [polkadot],
   solidity: "0.8.28",
   networks: {
-    hardhat: {
+    default: {
       polkadot: {
         target: "evm"
       },

--- a/packages/hardhat-polkadot/sample-projects/javascript/hardhat.config.js
+++ b/packages/hardhat-polkadot/sample-projects/javascript/hardhat.config.js
@@ -6,7 +6,7 @@ module.exports = defineConfig({
     plugins: [polkadot],
     solidity: "0.8.28",
     networks: {
-        hardhat: {
+        default: {
             polkadot: {
                 target: "evm",
             },

--- a/packages/hardhat-polkadot/sample-projects/typescript-viem/hardhat.config.ts
+++ b/packages/hardhat-polkadot/sample-projects/typescript-viem/hardhat.config.ts
@@ -5,7 +5,7 @@ export default defineConfig({
     plugins: [polkadot],
     solidity: "0.8.28",
     networks: {
-        hardhat: {
+        default: {
             polkadot: {
                 target: "evm",
             },

--- a/packages/hardhat-polkadot/sample-projects/typescript/hardhat.config.ts
+++ b/packages/hardhat-polkadot/sample-projects/typescript/hardhat.config.ts
@@ -5,7 +5,7 @@ export default defineConfig({
     plugins: [polkadot],
     solidity: "0.8.28",
     networks: {
-        hardhat: {
+        default: {
             polkadot: {
                 target: "evm",
             },

--- a/packages/hardhat-polkadot/src/cli/project-creation.ts
+++ b/packages/hardhat-polkadot/src/cli/project-creation.ts
@@ -204,7 +204,7 @@ module.exports = defineConfig({
   plugins: [polkadot],
   solidity: "0.8.28",
   networks: {
-    hardhat: {
+    default: {
       polkadot: true,
     },
   },

--- a/tests/fixture-projects/basic-compile.config.js
+++ b/tests/fixture-projects/basic-compile.config.js
@@ -5,7 +5,7 @@ export default defineConfig({
     plugins: [polkadot],
     solidity: "0.8.28",
     networks: {
-        hardhat: {
+        default: {
             polkadot: true,
         },
     },

--- a/tests/fixture-projects/basic-test-and-deploy.config.js
+++ b/tests/fixture-projects/basic-test-and-deploy.config.js
@@ -5,7 +5,7 @@ export default defineConfig({
     plugins: [polkadot],
     solidity: "0.8.28",
     networks: {
-        hardhat: {
+        default: {
             polkadot: true,
             docker: true,
         },

--- a/tests/fixture-projects/forking.config.js
+++ b/tests/fixture-projects/forking.config.js
@@ -5,7 +5,7 @@ export default defineConfig({
     plugins: [polkadot],
     solidity: "0.8.28",
     networks: {
-        hardhat: {
+        default: {
             polkadot: true,
             docker: true,
             forking: {


### PR DESCRIPTION
On HH3, default network has changed from "hardhat" to "default". These changes reflect that.